### PR TITLE
Smoother animations on Top-Sellers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,13 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^0.27.2",
         "firebase": "^9.8.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
-        "react-owl-carousel": "^2.3.3",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
-        "web-vitals": "^2.1.4",
-        "wowjs": "^1.1.3"
+        "web-vitals": "^2.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4828,11 +4825,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5051,28 +5043,6 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -11152,11 +11122,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12152,14 +12117,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "dependencies": {
-        "jquery": ">=1.8.3"
       }
     },
     "node_modules/p-limit": {
@@ -13975,56 +13932,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "dependencies": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "peerDependencies": {
-        "jquery": ">=1.8.3",
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15833,19 +15740,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -16796,14 +16690,6 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.1"
-      }
-    },
-    "node_modules/wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "dependencies": {
-        "animate.css": "latest"
       }
     },
     "node_modules/wrap-ansi": {
@@ -18449,14 +18335,12 @@
     "@firebase/auth-interop-types": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
-      "requires": {}
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
     },
     "@firebase/auth-types": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
-      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
-      "requires": {}
+      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw=="
     },
     "@firebase/component": {
       "version": "0.5.16",
@@ -18532,8 +18416,7 @@
     "@firebase/firestore-types": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
-      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
-      "requires": {}
+      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA=="
     },
     "@firebase/functions": {
       "version": "0.8.3",
@@ -18736,8 +18619,7 @@
     "@firebase/storage-types": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
-      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
-      "requires": {}
+      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA=="
     },
     "@firebase/util": {
       "version": "1.6.2",
@@ -20350,14 +20232,12 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "requires": {}
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -20452,13 +20332,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
-    },
-    "animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -20610,27 +20484,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -20781,8 +20634,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "requires": {}
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -21517,8 +21369,7 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "requires": {}
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
     },
     "css-select": {
       "version": "4.2.1",
@@ -21622,8 +21473,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -22505,8 +22355,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "requires": {}
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
     },
     "eslint-plugin-testing-library": {
       "version": "5.0.6",
@@ -23424,8 +23273,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "idb": {
       "version": "6.1.5",
@@ -24445,8 +24293,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -25045,11 +24892,6 @@
           }
         }
       }
-    },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -25798,14 +25640,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "requires": {
-        "jquery": ">=1.8.3"
-      }
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -26078,8 +25912,7 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "requires": {}
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -26136,8 +25969,7 @@
     "postcss-custom-media": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "requires": {}
+      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g=="
     },
     "postcss-custom-properties": {
       "version": "12.1.4",
@@ -26166,26 +25998,22 @@
     "postcss-discard-comments": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
-      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "requires": {}
+      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -26207,8 +26035,7 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "requires": {}
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -26229,14 +26056,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
-      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "requires": {}
+      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ=="
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -26249,8 +26074,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -26291,14 +26115,12 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "requires": {}
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "requires": {}
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
     },
     "postcss-merge-longhand": {
       "version": "5.1.0",
@@ -26359,8 +26181,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -26417,8 +26238,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26503,14 +26323,12 @@
     "postcss-overflow-shorthand": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
-      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "requires": {}
+      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg=="
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -26597,8 +26415,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -26998,55 +26815,12 @@
     "react-icons": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
-      "requires": {}
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ=="
     },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "requires": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
     },
     "react-refresh": {
       "version": "0.11.0",
@@ -27943,8 +27717,7 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "requires": {}
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -28397,12 +28170,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "peer": true
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -28767,8 +28534,7 @@
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
         }
       }
     },
@@ -29150,14 +28916,6 @@
         "workbox-core": "6.5.1"
       }
     },
-    "wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "requires": {
-        "animate.css": "latest"
-      }
-    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -29210,8 +28968,7 @@
     "ws": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "requires": {}
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
         "@types/react-slick": "^0.23.13",
+        "aos": "^2.3.4",
         "axios": "^1.8.3",
         "firebase": "^9.8.4",
         "keen-slider": "^6.8.6",
@@ -4895,6 +4896,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aos": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
+      "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "license": "MIT",
+      "dependencies": {
+        "classlist-polyfill": "^1.0.3",
+        "lodash.debounce": "^4.0.6",
+        "lodash.throttle": "^4.0.1"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
@@ -5778,6 +5790,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
+      "license": "Unlicense"
     },
     "node_modules/clean-css": {
       "version": "5.2.4",
@@ -11614,6 +11632,12 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -20575,6 +20599,16 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aos": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
+      "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "requires": {
+        "classlist-polyfill": "^1.0.3",
+        "lodash.debounce": "^4.0.6",
+        "lodash.throttle": "^4.0.1"
+      }
+    },
     "arg": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
@@ -21243,6 +21277,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "clean-css": {
       "version": "5.2.4",
@@ -25460,6 +25499,11 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,17 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "@types/react-slick": "^0.23.13",
+        "axios": "^1.8.3",
         "firebase": "^9.8.4",
+        "keen-slider": "^6.8.6",
+        "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
+        "slick-carousel": "^1.8.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -4193,6 +4198,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.13",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.13.tgz",
+      "integrity": "sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5045,6 +5059,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -5571,6 +5611,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -6839,6 +6892,20 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6969,10 +7036,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -8094,15 +8206,16 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -8346,9 +8459,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -8372,13 +8489,24 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8395,6 +8523,19 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -8520,6 +8661,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -8577,9 +8730,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8588,17 +8742,30 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -11298,6 +11465,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/keen-slider": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/keen-slider/-/keen-slider-6.8.6.tgz",
+      "integrity": "sha512-dcEQ7GDBpCjUQA8XZeWh3oBBLLmyn8aoeIQFGL/NTVkoEOsmlnXqA4QykUm/SncolAZYGsEk/PfUhLZ7mwMM2w==",
+      "license": "MIT"
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -11414,7 +11587,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -11525,6 +11699,15 @@
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -13636,6 +13819,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -14788,6 +14977,15 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
       }
     },
     "node_modules/sockjs": {
@@ -19860,6 +20058,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-slick": {
+      "version": "0.23.13",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.13.tgz",
+      "integrity": "sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -20484,6 +20690,29 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+          "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -20894,6 +21123,15 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       }
     },
     "callsites": {
@@ -21823,6 +22061,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -21923,10 +22171,39 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
     "es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -22756,9 +23033,9 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -22915,9 +23192,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -22935,13 +23212,20 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -22953,6 +23237,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -23040,6 +23333,11 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -23082,16 +23380,24 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -25037,6 +25343,11 @@
         }
       }
     },
+    "keen-slider": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/keen-slider/-/keen-slider-6.8.6.tgz",
+      "integrity": "sha512-dcEQ7GDBpCjUQA8XZeWh3oBBLLmyn8aoeIQFGL/NTVkoEOsmlnXqA4QykUm/SncolAZYGsEk/PfUhLZ7mwMM2w=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -25219,6 +25530,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "mdn-data": {
       "version": "2.0.4",
@@ -26612,6 +26928,11 @@
         }
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -27463,6 +27784,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
     },
     "sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,17 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "@types/react-slick": "^0.23.13",
+    "axios": "^1.8.3",
     "firebase": "^9.8.4",
+    "keen-slider": "^6.8.6",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
+    "slick-carousel": "^1.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
     "@types/react-slick": "^0.23.13",
+    "aos": "^2.3.4",
     "axios": "^1.8.3",
     "firebase": "^9.8.4",
     "keen-slider": "^6.8.6",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
-        <Route path="/author" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/author/:id" element={<Author />} />
+        <Route path="/item-details/:id" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,14 +7,17 @@ import Nav from "./components/Nav";
 import Footer from "./components/Footer";
 
 function App() {
+
+  
+
   return (
     <Router>
       <Nav />
       <Routes>
-        <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/author/:id" element={<Author />} />
         <Route path="/item-details/:id" element={<ItemDetails />} />
+        <Route path='/*' element={<Home />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/UI/NftCard.jsx
+++ b/src/components/UI/NftCard.jsx
@@ -19,7 +19,9 @@ function NftCard({item, index, likedArray, handleLikes}) {
                 <i className="fa fa-check"></i>
               </Link>
             </div>
+            {item.expiryDate  && 
             <Countdown time={item.expiryDate} />
+            }
 
             <div className="nft__item_wrap">
               <div className="nft__item_extra">

--- a/src/components/UI/NftCard.jsx
+++ b/src/components/UI/NftCard.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import Countdown from '../home/Countdown'
+
+function NftCard({item, index, likedArray, handleLikes}) {
+  return (
+    <div
+          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+          style={{ display: "block", backgroundSize: "cover" }}
+        >
+          <div className="nft__item">
+            <div className="author_list_pp">
+              <Link
+                to={`/author/${item.authorId}`}
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+              >
+                <img className="lazy" src={item.authorImage} alt="" />
+                <i className="fa fa-check"></i>
+              </Link>
+            </div>
+            <Countdown time={item.expiryDate} />
+
+            <div className="nft__item_wrap">
+              <div className="nft__item_extra">
+                <div className="nft__item_buttons">
+                  <button>Buy Now</button>
+                  <div className="nft__item_share">
+                    <h4>Share</h4>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-facebook fa-lg"></i>
+                    </a>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-twitter fa-lg"></i>
+                    </a>
+                    <a href="">
+                      <i className="fa fa-envelope fa-lg"></i>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <Link to={`/item-details/${item.nftId}`}>
+                <img src={item.nftImage} className="lazy nft__item_preview" alt="" />
+              </Link>
+            </div>
+            <div className="nft__item_info">
+              <Link to={`/item-details/${item.nftId}`}>
+                <h4>{item.title}</h4>
+              </Link>
+              <div className="nft__item_price">{item.price} ETH</div>
+              <div className="nft__item_like">
+              <i id={`likeButton${index}`} className="fa fa-heart" onClick={() => handleLikes(index)} />
+              <span>{(likedArray.some(value => value === index)) ? (item.likes + 1) : (item.likes)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+  )
+}
+
+export default NftCard

--- a/src/components/UI/NftCard.jsx
+++ b/src/components/UI/NftCard.jsx
@@ -8,7 +8,7 @@ function NftCard({item, index, likedArray, handleLikes}) {
           className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
           style={{ display: "block", backgroundSize: "cover" }}
         >
-          <div className="nft__item">
+          <div className="nft__item" data-aos="fade-up" data-aos-delay={200 * index} data-aos-anchor-placement='top-bottom'>
             <div className="author_list_pp">
               <Link
                 to={`/author/${item.authorId}`}

--- a/src/components/UI/NftCardSkeleton.jsx
+++ b/src/components/UI/NftCardSkeleton.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import Skeleton from './Skeleton'
+
+function NftCardSkeleton() {
+  return (
+    <div
+          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+          style={{ display: "block", backgroundSize: "cover" }}
+        >
+          <div className="nft__item">
+            <div className="author_list_pp">
+                <Skeleton width={'3rem'} height={"3rem"} borderRadius={'50%'}  />
+            </div>
+            <div className="nft__item_wrap">
+              <div className="nft__item_extra">
+                <div className="nft__item_buttons">
+                  <button>Buy Now</button>
+                  <div className="nft__item_share">
+                    <h4>Share</h4>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-facebook fa-lg"></i>
+                    </a>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-twitter fa-lg"></i>
+                    </a>
+                    <a href="">
+                      <i className="fa fa-envelope fa-lg"></i>
+                    </a>
+                  </div>
+                </div>
+              </div>
+                <Skeleton height={'50%'} width={'100%'} borderRadius={'0'} />
+            </div>
+            <div className="nft__item_info w-100">
+                <div className="">
+                <div className="w-50 flex-column">
+                    <Skeleton height={'1rem'} width={'100%'} borderRadius={'0'} />
+                    <Skeleton height={'1rem'} width={'100%'} borderRadius={'0'} />
+                </div>
+                <div className="nft__item_like flex w-50 align-items-end skeleton-info-adjust">
+                    <i className="fa fa-heart mr-1" />
+                    <Skeleton height={'1rem'} width={'25%'} borderRadius={'0'} />
+                </div>
+                </div>
+            </div>
+          </div>
+        </div>
+  )
+}
+
+export default NftCardSkeleton

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -1,60 +1,45 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 import nftImage from "../../images/nftImage.jpg";
+import NftCard from '../UI/NftCard'
+import NftCardSkeleton from "../UI/NftCardSkeleton";
+ 
+const AuthorItems = ({ data, authorImage, loading, authorId }) => {
+    const [likedArray, setLikedArray] = useState(new Array())
+  
+    function handleLikes(index) {
+      const item = document.getElementById(`likeButton${index}`)
+      if (likedArray.some((value) => value === index)) {
+        setLikedArray(likedArray.filter((value) => value !== index))
+        item?.classList.remove('user-liked')
+      }
+      else {
+        setLikedArray([...likedArray, index])
+        item?.classList.add('user-liked')
+      }
+    }
 
-const AuthorItems = () => {
+  if (loading) {
+    return (
+      <div className="de_tab_content">
+      <div className="tab-1">
+        <div className="row">
+          {new Array(8).fill(0).map((_, index) => (
+            <NftCardSkeleton key={index} />
+          ))}
+        </div>
+      </div>
+    </div>
+    )
+  }  
+
   return (
     <div className="de_tab_content">
       <div className="tab-1">
         <div className="row">
-          {new Array(8).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link to="">
-                    <img className="lazy" src={AuthorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <div className="nft__item_price">2.52 ETH</div>
-                  <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>97</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+          {data.map((item, index) => (
+            <NftCard key={item.id} item={{...item, authorImage, authorId}} likedArray={likedArray} handleLikes={handleLikes} index={index} />
           ))}
         </div>
       </div>

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -1,7 +1,4 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
 import NftCard from '../UI/NftCard'
 import NftCardSkeleton from "../UI/NftCardSkeleton";
  

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -55,7 +55,7 @@ const ExploreItems = () => {
       </div>
       {
         new Array(8).fill(0).map((_, index) => (
-            <NftCardSkeleton />
+            <NftCardSkeleton key={index} />
         ))}
         </>
         )

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,80 +1,99 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import NftCard from '../UI/NftCard'
+import NftCardSkeleton from '../UI/NftCardSkeleton'
 
 const ExploreItems = () => {
+  const [exploreData, setExploreData] = useState();
+  const [loading, setLoading] = useState(true);
+  const [apiString, setApiString] = useState('https://us-central1-nft-cloud-functions.cloudfunctions.net/explore')
+  const [shownItems, setShownItems] = useState(8);
+  const baseApiString = 'https://us-central1-nft-cloud-functions.cloudfunctions.net/explore'
+  useEffect(() => {
+    
+    window.scrollTo(0, 0);
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const result = await axios.get(apiString)
+        setExploreData(result.data)
+      } catch (error) {
+        console.log('[EXPLORE_PAGE_API_REQUEST_ERROR]: ', error) 
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData();
+
+  }, [apiString]);
+
+  const [likedArray, setLikedArray] = useState(new Array())
+
+  function handleLikes(index) {
+    const item = document.getElementById(`likeButton${index}`)
+    if (likedArray.some((value) => value === index)) {
+      setLikedArray(likedArray.filter((value) => value !== index))
+      item?.classList.remove('user-liked')
+    }
+    else {
+      setLikedArray([...likedArray, index])
+      item?.classList.add('user-liked')
+    }
+  }
+
+
+  if ( loading ) {
+    return (
+    <>
+      <div>
+        <select id="filter-items" disabled onChange={(e) => {setApiString(baseApiString + e.target.value); setShownItems(8)}} defaultValue="">
+          <option value="">Default</option>
+          <option value="?filter=price_low_to_high">Price, Low to High</option>
+          <option value="?filter=price_high_to_low">Price, High to Low</option>
+          <option value="?filter=likes_high_to_low">Most liked</option>
+        </select>
+      </div>
+      {
+        new Array(8).fill(0).map((_, index) => (
+            <NftCardSkeleton />
+        ))}
+        </>
+        )
+      
+    
+  }
+
   return (
     <>
       <div>
-        <select id="filter-items" defaultValue="">
+        <select id="filter-items" onChange={(e) => {setApiString(baseApiString + e.target.value); setShownItems(8)}} defaultValue="">
           <option value="">Default</option>
-          <option value="price_low_to_high">Price, Low to High</option>
-          <option value="price_high_to_low">Price, High to Low</option>
-          <option value="likes_high_to_low">Most liked</option>
+          <option value="?filter=price_low_to_high">Price, Low to High</option>
+          <option value="?filter=price_high_to_low">Price, High to Low</option>
+          <option value="?filter=likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
-            </div>
-            <div className="de_countdown">5h 30m 32s</div>
 
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
-            </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
-          </div>
+      {/* Grid container */}
+      {exploreData.map((item, index) => {
+        if (index < shownItems) {
+          return (
+            <NftCard key={item.id} item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
+          )
+        }
+      })}
+      {/* Load more button */}
+      {exploreData && exploreData.length > shownItems && (
+        <div className="col-md-12 text-center">
+          <button 
+            onClick={() => setShownItems(prev => prev + 4)}
+            className="btn-main lead"
+          >
+            Load More
+          </button>
         </div>
-      ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
-      </div>
+      )}
     </>
-  );
+  )
 };
-
-export default ExploreItems;
+  export default ExploreItems;

--- a/src/components/home/BrowseByCategory.jsx
+++ b/src/components/home/BrowseByCategory.jsx
@@ -13,37 +13,37 @@ const BrowseByCategory = () => {
             </div>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='50' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-image"></i>
               <span>Art</span>
             </Link>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='250' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-music"></i>
               <span>Music</span>
             </Link>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='500' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-search"></i>
               <span>Domain Names</span>
             </Link>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='750' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-globe"></i>
               <span>Virtual Worlds</span>
             </Link>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='1000' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-vcard"></i>
               <span>Trading Cards</span>
             </Link>
           </div>
           <div className="col-md-2 col-sm-4 col-6 mb-sm-30">
-            <Link to="/explore" className="icon-box style-2 rounded">
+            <Link data-aos='fade-left' data-aos-delay='1250' to="/explore" className="icon-box style-2 rounded">
               <i className="fa fa-th"></i>
               <span>Collectibles</span>
             </Link>

--- a/src/components/home/CarouselArrow.jsx
+++ b/src/components/home/CarouselArrow.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+function Arrow(props) {
+    const disabled = props.disabled ? " arrow--disabled" : "";
+    return (
+      <svg
+        onClick={props.onClick}
+        className={`arrow ${
+          props.left ? "arrow--left" : "arrow--right"
+        } ${disabled}`}
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+      >
+        {props.left && (
+          <path d='M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z' />
+        )}
+        {!props.left && (
+          <path d='M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z' />
+        )}
+      </svg>
+    );
+  }
+
+  export default Arrow

--- a/src/components/home/CarouselArrow.jsx
+++ b/src/components/home/CarouselArrow.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+
+
 function Arrow(props) {
     const disabled = props.disabled ? " arrow--disabled" : "";
     return (

--- a/src/components/home/Countdown.jsx
+++ b/src/components/home/Countdown.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react'
+
+function Countdown({time}) {
+
+    const [currentTime, setCurrentTime] = useState(Date.now());
+
+    const timeLeft = time - currentTime;
+
+    const seconds = Math.floor((timeLeft / 1000) % 60);
+    const minutes = Math.floor((timeLeft / 1000 / 60) % 60)
+    const hours = Math.floor((timeLeft / 1000 / 60 / 60))
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setCurrentTime(Date.now())
+        }, 1000);
+
+        return () => clearInterval(interval)
+    }, [])
+
+    if (timeLeft <= 0) {
+        return null;
+    }
+
+  return (
+    <div className='de_countdown'>{ hours + 'h ' + minutes + "m " + seconds + 's' }</div>
+  )
+}
+
+export default Countdown

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -1,122 +1,120 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import 'keen-slider/keen-slider.min.css'
-import {useKeenSlider} from 'keen-slider/react'
+import "keen-slider/keen-slider.min.css";
+import { useKeenSlider } from "keen-slider/react";
+import Arrow from "./CarouselArrow";
 
-const HotCollections = ({data, items}) => {
+const HotCollections = ({ data, items }) => {
+  const [loaded, setLoaded] = useState(false);
+  const [sliderRef, instanceRef] = useKeenSlider({
+    initial: 0,
+    loop: true,
+    slides: {
+      perView: items,
+      spacing: 12,
+    },
+    created() {
+      setLoaded(true);
+    },
+  });
 
-  const [loaded, setLoaded] = useState(false)
-  const [sliderRef, instanceRef] = useKeenSlider(
-    {
-      initial: 0,
-      loop: true,
-      slides: {
-        perView: items,
-        spacing: 12
-      },
-      created() {
-        setLoaded(true)
-      },
-    }
-  )
-
-  
   return (
-    <section id="section-collections" className="no-bottom">
-      <div className="container">
-        <div className="row">
-          <div className="col-lg-12">
-            <div className="text-center">
+    <section
+      id='section-collections'
+      className='no-bottom'
+    >
+      <div className='container'>
+        <div className='row'>
+          <div className='col-lg-12'>
+            <div className='text-center'>
               <h2>Hot Collections</h2>
-              <div className="small-border bg-color-2"></div>
+              <div className='small-border bg-color-2'></div>
             </div>
           </div>
-          <div ref={sliderRef} className="keen-slider">
-          {data?.map((item) => (
-              item ? 
-              (
-              <div id='carousel-div' className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide" key={item.id}>
-              <div className="nft_coll">
-                <div className="nft_wrap">
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <img src={item.nftImage} className="lazy img-fluid" alt={`${item.title}`} />
-                  </Link>
+          <div
+            ref={sliderRef}
+            className='keen-slider'
+          >
+            {data?.map((item) =>
+              item ? (
+                <div
+                  id='carousel-div'
+                  className='col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide'
+                  key={item.id}
+                >
+                  <div className='nft_coll'>
+                    <div className='nft_wrap'>
+                      <Link to={`/item-details/${item.nftId}`}>
+                        <img
+                          src={item.nftImage}
+                          className='lazy img-fluid'
+                          alt={`${item.title}`}
+                        />
+                      </Link>
+                    </div>
+                    <div className='nft_coll_pp'>
+                      <Link to={`/author/${item.authorId}`}>
+                        <img
+                          className='lazy pp-coll'
+                          src={item.authorImage}
+                          alt={`${item.author}`}
+                        />
+                      </Link>
+                      <i className='fa fa-check'></i>
+                    </div>
+                    <div className='nft_coll_info'>
+                      <Link to={`/explore/${item.title}`}>
+                        <h4>{item.title}</h4>
+                      </Link>
+                      <span>ERC-{item.code}</span>
+                    </div>
+                  </div>
                 </div>
-                <div className="nft_coll_pp">
-                  <Link to={`/author/${item.author}`}>
-                    <img className="lazy pp-coll" src={item.authorImage} alt={`${item.author}`} />
-                  </Link>
-                  <i className="fa fa-check"></i>
+              ) : (
+                <div
+                  id='carousel-div'
+                  className='col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper'
+                  key={item.id}
+                >
+                  <div className='nft_coll'>
+                    <div className='nft_wrap'>
+                      <div className='lazy img-fluid skeleton-box skeleton-main' />
+                    </div>
+                    <div className='nft_coll_pp skeleton-auth'>
+                      <div className='lazy skeleton-box ' />
+                    </div>
+                    <div className='nft_coll_info'>
+                      <div className='w-25 skeleton-box'> </div>
+                    </div>
+                    <span className='w-25 skeleton-box'> </span>
+                  </div>
                 </div>
-                <div className="nft_coll_info">
-                  <Link to={`/explore/${item.title}`}>
-                    <h4>{item.title}</h4>
-                  </Link>
-                  <span>ERC-{item.code}</span>
-                </div>
-              </div>
-            </div>
-              ) : 
-              (
-                <div id='carousel-div' className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
-              <div className="nft_coll">
-                <div className="nft_wrap">
-                    <div className="lazy img-fluid skeleton-box skeleton-main"/>
-                </div>
-                <div className="nft_coll_pp skeleton-auth">
-                    <div className="lazy skeleton-box " />
-                </div>
-                <div className="nft_coll_info">
-                    <div className="w-25 skeleton-box">{" "}</div>
-                </div>
-                  <span className="w-25 skeleton-box">{" "}</span>
-              </div>
-            </div>
               )
-            ))}
-            
-          {loaded && instanceRef.current && (
-          <>
-            <Arrow
-              left
-              onClick={(e) =>
-                e.stopPropagation() || instanceRef.current?.prev()
-              }
-            />
+            )}
 
-            <Arrow
-              onClick={(e) =>
-                e.stopPropagation() || instanceRef.current?.next()
-              }
-            />
-          </>
-        )}
-      </div>
+            {loaded && instanceRef.current && (
+              <>
+                <Arrow
+                  left
+                  onClick={(e) =>
+                    e.stopPropagation() || instanceRef.current?.prev()
+                  }
+                />
+
+                <Arrow
+                  onClick={(e) =>
+                    e.stopPropagation() || instanceRef.current?.next()
+                  }
+                />
+              </>
+            )}
           </div>
+        </div>
       </div>
     </section>
   );
 };
 
-function Arrow(props) {
-  const disabled = props.disabled ? " arrow--disabled" : ""
-  return (
-    <svg
-      onClick={props.onClick}
-      className={`arrow ${
-        props.left ? "arrow--left" : "arrow--right"
-      } ${disabled}`}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-    >
-      {props.left && (
-        <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
-      )}
-      {!props.left && (
-        <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z" />
-      )}
-    </svg>
-  )
-}
+
 
 export default HotCollections;

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -3,8 +3,11 @@ import { Link } from "react-router-dom";
 import "keen-slider/keen-slider.min.css";
 import { useKeenSlider } from "keen-slider/react";
 import Arrow from "./CarouselArrow";
+import Aos from "aos";
+import 'aos/dist/aos.css'; 
 
 const HotCollections = ({ data, items }) => {
+  Aos.init()
   const [loaded, setLoaded] = useState(false);
   const [sliderRef, instanceRef] = useKeenSlider({
     initial: 0,
@@ -35,14 +38,14 @@ const HotCollections = ({ data, items }) => {
             ref={sliderRef}
             className='keen-slider'
           >
-            {data?.map((item) =>
+            {data?.map((item, index) =>
               item ? (
                 <div
                   id='carousel-div'
                   className='col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide'
                   key={item.id}
                 >
-                  <div className='nft_coll'>
+                  <div className='nft_coll' data-aos="fade-up" data-aos-delay={200 * index}>
                     <div className='nft_wrap'>
                       <Link to={`/item-details/${item.nftId}`}>
                         <img

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -1,9 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import 'keen-slider/keen-slider.min.css'
+import {useKeenSlider} from 'keen-slider/react'
 
-const HotCollections = () => {
+const HotCollections = ({data, items}) => {
+
+  const [loaded, setLoaded] = useState(false)
+  const [sliderRef, instanceRef] = useKeenSlider(
+    {
+      initial: 0,
+      loop: true,
+      slides: {
+        perView: items,
+        spacing: 12
+      },
+      created() {
+        setLoaded(true)
+      },
+    }
+  )
+
+  
   return (
     <section id="section-collections" className="no-bottom">
       <div className="container">
@@ -14,33 +31,92 @@ const HotCollections = () => {
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
+          <div ref={sliderRef} className="keen-slider">
+          {data?.map((item) => (
+              item ? 
+              (
+              <div id='carousel-div' className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide" key={item.id}>
               <div className="nft_coll">
                 <div className="nft_wrap">
-                  <Link to="/item-details">
-                    <img src={nftImage} className="lazy img-fluid" alt="" />
+                  <Link to={`/item-details/${item.nftId}`}>
+                    <img src={item.nftImage} className="lazy img-fluid" alt={`${item.title}`} />
                   </Link>
                 </div>
                 <div className="nft_coll_pp">
-                  <Link to="/author">
-                    <img className="lazy pp-coll" src={AuthorImage} alt="" />
+                  <Link to={`/author/${item.author}`}>
+                    <img className="lazy pp-coll" src={item.authorImage} alt={`${item.author}`} />
                   </Link>
                   <i className="fa fa-check"></i>
                 </div>
                 <div className="nft_coll_info">
-                  <Link to="/explore">
-                    <h4>Pinky Ocean</h4>
+                  <Link to={`/explore/${item.title}`}>
+                    <h4>{item.title}</h4>
                   </Link>
-                  <span>ERC-192</span>
+                  <span>ERC-{item.code}</span>
                 </div>
               </div>
             </div>
-          ))}
-        </div>
+              ) : 
+              (
+                <div id='carousel-div' className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
+              <div className="nft_coll">
+                <div className="nft_wrap">
+                    <div className="lazy img-fluid skeleton-box skeleton-main"/>
+                </div>
+                <div className="nft_coll_pp skeleton-auth">
+                    <div className="lazy skeleton-box " />
+                </div>
+                <div className="nft_coll_info">
+                    <div className="w-25 skeleton-box">{" "}</div>
+                </div>
+                  <span className="w-25 skeleton-box">{" "}</span>
+              </div>
+            </div>
+              )
+            ))}
+            
+          {loaded && instanceRef.current && (
+          <>
+            <Arrow
+              left
+              onClick={(e) =>
+                e.stopPropagation() || instanceRef.current?.prev()
+              }
+            />
+
+            <Arrow
+              onClick={(e) =>
+                e.stopPropagation() || instanceRef.current?.next()
+              }
+            />
+          </>
+        )}
+      </div>
+          </div>
       </div>
     </section>
   );
 };
+
+function Arrow(props) {
+  const disabled = props.disabled ? " arrow--disabled" : ""
+  return (
+    <svg
+      onClick={props.onClick}
+      className={`arrow ${
+        props.left ? "arrow--left" : "arrow--right"
+      } ${disabled}`}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      {props.left && (
+        <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
+      )}
+      {!props.left && (
+        <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z" />
+      )}
+    </svg>
+  )
+}
 
 export default HotCollections;

--- a/src/components/home/Landing.jsx
+++ b/src/components/home/Landing.jsx
@@ -2,8 +2,11 @@ import React from "react";
 import NFT from "../../images/nft.png";
 import backgroundImage from "../../images/bg-shape-1.jpg";
 import { Link } from "react-router-dom";
+import Aos from "aos";
+import 'aos/dist/aos.css'; 
 
 const Landing = () => {
+  Aos.init()
   return (
     <section
       id="section-hero"
@@ -18,25 +21,25 @@ const Landing = () => {
             <div className="col-md-6">
               <div className="spacer-single"></div>
               <h6>
-                <span className="text-uppercase id-color-2">
+                <span data-aos="fade-up" data-aos-delay="50" data-aos-duration="1000" className="text-uppercase id-color-2">
                   Ultraverse Market
                 </span>
               </h6>
               <div className="spacer-10"></div>
-              <h1>Create, sell or collect digital items.</h1>
-              <p className="lead">
+              <h1 data-aos="fade-up" data-aos-delay="300" data-aos-duration="1000">Create, sell or collect digital items.</h1>
+              <p data-aos="fade-up" data-aos-delay="550" data-aos-duration="1000" className="lead">
                 Unit of data stored on a digital ledger, called a blockchain,
                 that certifies a digital asset to be unique and therefore not
                 interchangeable
               </p>
               <div className="spacer-10"></div>
-              <Link className="btn-main lead" to="/explore">
+              <Link data-aos="fade-up" data-aos-delay="700" data-aos-duration="1000" className="btn-main lead" to="/explore">
                 Explore
               </Link>
               <div className="mb-sm-30"></div>
             </div>
             <div className="col-md-6 xs-hide">
-              <img src={NFT} className="lazy img-fluid" alt="" />
+              <img src={NFT} data-aos="fade-left" data-aos-delay='300' data-aos-duration='1500' className="lazy img-fluid" alt="" />
             </div>
           </div>
         </div>

--- a/src/components/home/LandingIntro.jsx
+++ b/src/components/home/LandingIntro.jsx
@@ -1,11 +1,14 @@
 import React from "react";
+import Aos from "aos";
+import 'aos/dist/aos.css'; 
 
 const LandingIntro = () => {
+  Aos.init()
   return (
     <section id="section-intro" className="no-top no-bottom">
       <div className="container">
         <div className="row">
-          <div className="col-lg-4 col-md-6 mb-sm-30">
+          <div data-aos="fade-left" data-aos-delay="50" data-aos-duration="1000" className="col-lg-4 col-md-6 mb-sm-30">
             <div className="feature-box f-boxed style-3">
               <i className="bg-color-2 i-boxed icon_wallet"></i>
               <div className="text">
@@ -18,7 +21,7 @@ const LandingIntro = () => {
               <i className="wm icon_wallet"></i>
             </div>
           </div>
-          <div className="col-lg-4 col-md-6 mb-sm-30">
+          <div data-aos="fade-left" data-aos-delay="300" data-aos-duration="1000" className="col-lg-4 col-md-6 mb-sm-30">
             <div className="feature-box f-boxed style-3">
               <i className="bg-color-2 i-boxed icon_cloud-upload_alt"></i>
               <div className="text">
@@ -31,7 +34,7 @@ const LandingIntro = () => {
               <i className="wm icon_cloud-upload_alt"></i>
             </div>
           </div>
-          <div className="col-lg-4 col-md-6 mb-sm-30">
+          <div data-aos="fade-left" data-aos-delay="600" data-aos-duration="1000" className="col-lg-4 col-md-6 mb-sm-30">
             <div className="feature-box f-boxed style-3">
               <i className="bg-color-2 i-boxed icon_tags_alt"></i>
               <div className="text">

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
 import { useKeenSlider } from "keen-slider/react";
 import Arrow from "./CarouselArrow";
-import Countdown from "./Countdown";
 import NftCard from "../UI/NftCard";
+import Aos from "aos";
+import 'aos/dist/aos.css'; 
 
 const NewItems = ({data, items}) => {
-
+  Aos.init();
   const [likedArray, setLikedArray] = useState(new Array())
 
   function handleLikes(index) {
@@ -96,7 +96,7 @@ const NewItems = ({data, items}) => {
             )
           ))}
           {loaded && instanceRef.current && (
-              <>
+              <div>
                 <Arrow
                   left
                   onClick={() =>
@@ -109,7 +109,7 @@ const NewItems = ({data, items}) => {
                     instanceRef.current?.next()
                   }
                 />
-              </>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,9 +1,40 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import { useKeenSlider } from "keen-slider/react";
+import Arrow from "./CarouselArrow";
+import Countdown from "./Countdown";
 
-const NewItems = () => {
+const NewItems = ({data, items}) => {
+
+  const [likedArray, setLikedArray] = useState(new Array())
+
+  function handleLikes(index) {
+    const item = document.getElementById(`likeButton${index}`)
+    if (likedArray.some((value) => value === index)) {
+      setLikedArray(likedArray.filter((value) => value !== index))
+      item?.classList.remove('user-liked')
+    }
+    else {
+      setLikedArray([...likedArray, index])
+      item?.classList.add('user-liked')
+    }
+  }
+
+  const [loaded, setLoaded] = useState(false)
+    const [sliderRef, instanceRef] = useKeenSlider(
+      {
+        initial: 0,
+        loop: true,
+        slides: {
+          perView: items,
+          spacing: 12
+        },
+        created() {
+          setLoaded(true)
+        },
+      }
+    )
+    
   return (
     <section id="section-items" className="no-bottom">
       <div className="container">
@@ -14,22 +45,26 @@ const NewItems = () => {
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
+          <div
+            ref={sliderRef}
+            className='keen-slider'
+          >
+          {data?.map((item, index) => (
+            item ? (
+            <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide" key={item.id}>
               <div className="nft__item">
                 <div className="author_list_pp">
                   <Link
-                    to="/author"
+                    to={`/author/${item.authorId}`}
                     data-bs-toggle="tooltip"
                     data-bs-placement="top"
                     title="Creator: Monica Lucas"
                   >
-                    <img className="lazy" src={AuthorImage} alt="" />
+                    <img className="lazy" src={item.authorImage} alt="" />
                     <i className="fa fa-check"></i>
                   </Link>
                 </div>
-                <div className="de_countdown">5h 30m 32s</div>
-
+                <Countdown time={item.expiryDate} />
                 <div className="nft__item_wrap">
                   <div className="nft__item_extra">
                     <div className="nft__item_buttons">
@@ -49,27 +84,85 @@ const NewItems = () => {
                     </div>
                   </div>
 
-                  <Link to="/item-details">
+                  <Link to={`/item-details/${item.nftId}`}>
                     <img
-                      src={nftImage}
+                      src={item.nftImage}
                       className="lazy nft__item_preview"
-                      alt=""
+                      alt={item.title}
                     />
                   </Link>
                 </div>
                 <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
+                  <Link to={`/item-details/${item.nftId}`}>
+                    <h4>{item.title}</h4>
                   </Link>
-                  <div className="nft__item_price">3.08 ETH</div>
+                  <div className="nft__item_price">{item.price + ' '}ETH</div>
                   <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>69</span>
+                    <i id={`likeButton${index}`} className="fa fa-heart" onClick={() => handleLikes(index)} />
+                    <span>{(likedArray.some(value => value === index)) ? (item.likes + 1) : (item.likes)}</span>
                   </div>
                 </div>
               </div>
             </div>
+            ) : (
+              <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
+              <div className="nft__item">
+                <div className="author_list_pp skeleton-auth-new skeleton-box">
+                    <div className="lazy" />
+                </div>
+                <div className="nft__item_wrap">
+                  <div className="nft__item_extra">
+                    <div className="nft__item_buttons">
+                      <button>Buy Now</button>
+                      <div className="nft__item_share">
+                        <h4>Share</h4>
+                        <a href="" target="_blank" rel="noreferrer">
+                          <i className="fa fa-facebook fa-lg"></i>
+                        </a>
+                        <a href="" target="_blank" rel="noreferrer">
+                          <i className="fa fa-twitter fa-lg"></i>
+                        </a>
+                        <a href="">
+                          <i className="fa fa-envelope fa-lg"></i>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                    <div
+                      className="lazy skeleton-box skeleton-main"
+                    />
+                </div>
+                <div className=" skeleton-info-new">
+                    <h4 className="skeleton-name skeleton-box">{' '}</h4>
+                  <div className="skeleton-flex">
+                  <div> <h4 className="skeleton-box skeleton-info-price">{ ' '}</h4> <span className="">ETH</span></div>
+                  <div className="">
+                    <i className="fa fa-heart"></i>
+                    <h4 className="skeleton-info-like skeleton-box">{' '}</h4>
+                  </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            )
           ))}
+          {loaded && instanceRef.current && (
+              <>
+                <Arrow
+                  left
+                  onClick={() =>
+                    instanceRef.current?.prev()
+                  }
+                />
+
+                <Arrow
+                  onClick={() =>
+                    instanceRef.current?.next()
+                  }
+                />
+              </>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useKeenSlider } from "keen-slider/react";
 import Arrow from "./CarouselArrow";
 import Countdown from "./Countdown";
+import NftCard from "../UI/NftCard";
 
 const NewItems = ({data, items}) => {
 
@@ -51,59 +52,7 @@ const NewItems = ({data, items}) => {
           >
           {data?.map((item, index) => (
             item ? (
-            <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide" key={item.id}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link
-                    to={`/author/${item.authorId}`}
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="Creator: Monica Lucas"
-                  >
-                    <img className="lazy" src={item.authorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <Countdown time={item.expiryDate} />
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <img
-                      src={item.nftImage}
-                      className="lazy nft__item_preview"
-                      alt={item.title}
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <h4>{item.title}</h4>
-                  </Link>
-                  <div className="nft__item_price">{item.price + ' '}ETH</div>
-                  <div className="nft__item_like">
-                    <i id={`likeButton${index}`} className="fa fa-heart" onClick={() => handleLikes(index)} />
-                    <span>{(likedArray.some(value => value === index)) ? (item.likes + 1) : (item.likes)}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <NftCard item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
             ) : (
               <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
               <div className="nft__item">

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -52,7 +52,7 @@ const NewItems = ({data, items}) => {
           >
           {data?.map((item, index) => (
             item ? (
-            <NftCard item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
+            <NftCard key={item.id} item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
             ) : (
               <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
               <div className="nft__item">

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -20,7 +20,7 @@ const TopSellers = ({data}) => {
             <ol className="author_list">
               { data ? (
                 data?.map((item, index) => (
-                  <li key={item.id} data-aos='fade-up' data-aos-delay={100 * index}>
+                  <li key={item.id} data-aos='fade-up' data-aos-delay={250 * ((index % 3) / 1)} data-aos-offset={-300 * ((index % 3) / 1)}>
                     <div className="author_list_pp">
                       <Link to={`/author/${item.authorId}`}>
                         <img

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 
-const TopSellers = () => {
+const TopSellers = ({data}) => {
+  const fallback = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -15,24 +16,43 @@ const TopSellers = () => {
           </div>
           <div className="col-md-12">
             <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
-                    </Link>
-                  </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
-                  </div>
-                </li>
-              ))}
+              { data ? (
+                data?.map((item, index) => (
+                  <li key={item.id}>
+                    <div className="author_list_pp">
+                      <Link to={`/author/${item.authorId}`}>
+                        <img
+                          className="lazy pp-author"
+                          src={item.authorImage}
+                          alt=""
+                        />
+                        <i className="fa fa-check"></i>
+                      </Link>
+                    </div>
+                    <div className="author_list_info">
+                      <Link to="/author">{item.authorName}</Link>
+                      <span>{item.price + ' ETH'}</span>
+                    </div>
+                  </li>
+                    )
+                  )
+                ) : (
+                  fallback.map((_, index) => {
+                    return( 
+                  <li key={index}>
+                    <div className="author_list_pp skeleton-auth skeleton-auth-top">
+                        <div
+                          className="lazy skeleton-box"
+                        />
+                    </div>
+                    <div className="author_list_info skeleton-auth-info">
+                      <div className="skeleton-box skeleton-name-top"> </div>
+                      <span className="skeleton-box skeleton-price-top"> </span>
+                      <span className="skeleton-label-top">{' ETH '}</span>
+                    </div>
+                  </li>
+                )}))
+              }
             </ol>
           </div>
         </div>

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
+import Aos from "aos";
+import 'aos/dist/aos.css'; 
 
 const TopSellers = ({data}) => {
+  Aos.init();
   const fallback = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
   return (
     <section id="section-popular" className="pb-5">
@@ -18,7 +20,7 @@ const TopSellers = ({data}) => {
             <ol className="author_list">
               { data ? (
                 data?.map((item, index) => (
-                  <li key={item.id}>
+                  <li key={item.id} data-aos='fade-up' data-aos-delay={100 * index}>
                     <div className="author_list_pp">
                       <Link to={`/author/${item.authorId}`}>
                         <img

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -30,7 +30,7 @@ const TopSellers = ({data}) => {
                       </Link>
                     </div>
                     <div className="author_list_info">
-                      <Link to="/author">{item.authorName}</Link>
+                      <Link to={`/author/${item.authorId}`}>{item.authorName}</Link>
                       <span>{item.price + ' ETH'}</span>
                     </div>
                   </li>

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16841,3 +16841,10 @@ img {
   top: 75%;
 }
 
+
+.skeleton-info-adjust {
+  display: flex;
+  justify-content: end;
+  margin-right: 4px;
+}
+

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16714,3 +16714,49 @@ img {
 .no-cursor {
   cursor: not-allowed;
 }
+
+.arrow {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  fill: #fff;
+  cursor: pointer;
+  background-color: rgba(50, 50, 50, 0.8);
+  padding: 8px;
+  border-radius: 50%;
+}
+
+.arrow--left {
+  left: 24px;
+}
+
+.arrow--right {
+  left: auto;
+  right: 2px;
+}
+
+.skeleton-wrapper {
+  position: relative;
+}
+
+.skeleton-main {
+  height: 70%;
+  width: 100%
+}
+
+.skeleton-auth {
+  background: #dddbdd;
+  position: absolute;
+  width: 20%;
+  height: 22%;
+  border: white 1 solid;
+  top: 50%;
+  display: block;
+  z-index: 100;
+  left: 50%;
+  transform: translate(-50%, 20%);
+  border-radius: 50%;
+}

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16760,3 +16760,56 @@ img {
   transform: translate(-50%, 20%);
   border-radius: 50%;
 }
+
+.skeleton-auth-new {
+  background: #dddbdd;
+  position: absolute;
+  width: 18%;
+  height: 13%;
+  border: white 1 solid;
+  top: 2%;
+  display: block;
+  z-index: 100;
+  left: 5%;
+  border-radius: 50%;
+}
+
+.skeleton-info-new {
+  position: relative;
+}
+
+.skeleton-name {
+  position: absolute;
+  top: 10%;
+  left: 0%;
+  height: 20px;
+  width: 150px;
+  transform: translateY(-200%)
+}
+
+.skeleton-flex {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  transform: translateY(-30%)
+}
+
+.skeleton-info-price {
+  height: 1em;
+  transform: translateY(50%);
+  width: 50px;
+  display: inline-block;
+}
+
+.skeleton-info-like {
+  height: 1em;
+  transform: translateY(50%);
+  width: 20px;
+  margin-left: 4px;
+}
+
+.user-liked {
+  color: #ea3943;
+}

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16848,3 +16848,9 @@ img {
   margin-right: 4px;
 }
 
+.skeleton-author-name {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+}
+

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16813,3 +16813,31 @@ img {
 .user-liked {
   color: #ea3943;
 }
+
+.skeleton-auth-top {
+  height: 3rem;
+  width: 3rem;
+  top: 0%;
+  left: 0rem;
+  transform: translateY(-10%);
+}
+
+.skeleton-auth-info {
+  position: relative;
+  height: 2rem;
+  width: 100%;
+}
+
+.skeleton-name-top {
+  position: absolute;
+  height: 1rem;
+  width: 50%;
+}
+
+.skeleton-price-top {
+  position: absolute;
+  height: 1rem;
+  width: 25%;
+  top: 75%;
+}
+

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16854,3 +16854,15 @@ img {
   row-gap: 8px;
 }
 
+.item-liked.item_info_like {
+  color: red;
+  background-color: #ffa5a5;
+}
+
+.item_info_like {
+  transition: all 0.5s ease;
+}
+
+.fa.item-liked-heart {
+  color: red;
+}

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from "react";
 import AuthorBanner from "../images/author_banner.jpg";
 import AuthorItems from "../components/author/AuthorItems";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import axios from "axios";
 import Skeleton from "../components/UI/Skeleton";
+import Aos from 'aos';
+import 'aos/dist/aos.css'; 
 
 const Author = () => {
+  Aos.init()
   const { id } = useParams()
   const [authorData, setAuthorData] = useState();
   const [loading, setLoading] = useState(true);
@@ -45,6 +48,7 @@ const Author = () => {
           className="text-light"
           data-bgimage="url(images/author_banner.jpg) top"
           style={{ background: `url(${AuthorBanner}) top` }}
+          data-aos="fade-down" data-aos-duration='1000' data-aos-delay="50"
         ></section>
 
         <section aria-label="section">
@@ -53,7 +57,7 @@ const Author = () => {
               <div className="col-md-12">
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
-                    <div className="profile_avatar">
+                    <div className="profile_avatar" data-aos="fade-right" data-aos-duration='1000' data-aos-delay="50" >
                       <Skeleton height={'6rem'} width={"6rem"} borderRadius={'50%'} />
                       <div className="profile_name">
                         <div className="skeleton-author-name">
@@ -65,7 +69,7 @@ const Author = () => {
                     </div>
                   </div>
                   <div className="profile_follow de-flex">
-                    <div className="de-flex-col">
+                    <div className="de-flex-col" data-aos="fade-left" data-aos-duration='1000' data-aos-delay="50" >
                       <Skeleton height={'3rem'} width={'12rem'} borderRadius={'0'} />
                     </div>
                   </div>
@@ -96,6 +100,7 @@ const Author = () => {
           className="text-light"
           data-bgimage="url(images/author_banner.jpg) top"
           style={{ background: `url(${AuthorBanner}) top` }}
+          data-aos="fade-down" data-aos-duration='1000' data-aos-delay="550"
         ></section>
 
         <section aria-label="section">
@@ -104,7 +109,7 @@ const Author = () => {
               <div className="col-md-12">
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
-                    <div className="profile_avatar">
+                    <div className="profile_avatar" data-aos="fade-right" data-aos-duration='1000' data-aos-delay="50">
                       <img src={authorData?.authorImage} alt="" />
 
                       <i className="fa fa-check"></i>
@@ -123,7 +128,7 @@ const Author = () => {
                     </div>
                   </div>
                   <div className="profile_follow de-flex">
-                    <div className="de-flex-col">
+                    <div className="de-flex-col" data-aos="fade-left" data-aos-duration='1000' data-aos-delay="50" >
                       <div className="profile_follower">{(followed ? authorData?.followers + 1 : authorData?.followers) + ' followers'}</div>
                       <button onClick={handleFollow} className="btn-main">
                         {followed ? 'Unfollow' : 'Follow'}

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,10 +1,90 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import AuthorBanner from "../images/author_banner.jpg";
 import AuthorItems from "../components/author/AuthorItems";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import Skeleton from "../components/UI/Skeleton";
 
 const Author = () => {
+  const { id } = useParams()
+  const [authorData, setAuthorData] = useState();
+  const [loading, setLoading] = useState(true);
+  const [followed, setFollowed] = useState(false);
+  useEffect(() => {
+    try {
+      setLoading(true)
+      const searchString = `https://us-central1-nft-cloud-functions.cloudfunctions.net/authors?author=${id}`
+      async function fetchAuthor() {
+        const result = await axios.get(searchString)
+        setAuthorData(result.data)
+      }
+      fetchAuthor();
+      setLoading(false);
+    } catch (error) {
+      console.log('[FETCH_AUTHOR_DATA_ERROR]: ', error)
+    }
+  }, [id])
+
+  function handleFollow() {
+    setFollowed((prev) => {
+      console.log(!prev)
+      return !prev;
+    })
+    
+  }
+
+  if (loading) {
+    return (
+      <div id="wrapper">
+      <div className="no-bottom no-top" id="content">
+        <div id="top"></div>
+
+        <section
+          id="profile_banner"
+          aria-label="section"
+          className="text-light"
+          data-bgimage="url(images/author_banner.jpg) top"
+          style={{ background: `url(${AuthorBanner}) top` }}
+        ></section>
+
+        <section aria-label="section">
+          <div className="container">
+            <div className="row">
+              <div className="col-md-12">
+                <div className="d_profile de-flex">
+                  <div className="de-flex-col">
+                    <div className="profile_avatar">
+                      <Skeleton height={'6rem'} width={"6rem"} borderRadius={'50%'} />
+                      <div className="profile_name">
+                        <div className="skeleton-author-name">
+                          <Skeleton height={'1.5rem'} width={'10rem'} borderRadius={'0-'} />
+                          <Skeleton height={'1rem'} width={'8rem'} borderRadius={'0-'} />
+                          <Skeleton height={'1.2rem'} width={'10rem'} borderRadius={'0-'} />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="profile_follow de-flex">
+                    <div className="de-flex-col">
+                      <Skeleton height={'3rem'} width={'12rem'} borderRadius={'0'} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="col-md-12">
+                <div className="de_tab tab_simple">
+                  <AuthorItems data={undefined} loading={loading} authorImage={undefined} authorId={undefined} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    )
+  }
+  
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
@@ -25,17 +105,17 @@ const Author = () => {
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
                     <div className="profile_avatar">
-                      <img src={AuthorImage} alt="" />
+                      <img src={authorData?.authorImage} alt="" />
 
                       <i className="fa fa-check"></i>
                       <div className="profile_name">
                         <h4>
-                          Monica Lucas
-                          <span className="profile_username">@monicaaaa</span>
+                          {authorData?.authorName}
+                          <span className="profile_username">{authorData?.tag}</span>
                           <span id="wallet" className="profile_wallet">
-                            UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7
+                            {authorData?.address}
                           </span>
-                          <button id="btn_copy" title="Copy Text">
+                          <button id="btn_copy" title="Copy Text" onClick={() => {navigator.clipboard.writeText(authorData?.address)}}>
                             Copy
                           </button>
                         </h4>
@@ -44,10 +124,10 @@ const Author = () => {
                   </div>
                   <div className="profile_follow de-flex">
                     <div className="de-flex-col">
-                      <div className="profile_follower">573 followers</div>
-                      <Link to="#" className="btn-main">
-                        Follow
-                      </Link>
+                      <div className="profile_follower">{(followed ? authorData?.followers + 1 : authorData?.followers) + ' followers'}</div>
+                      <button onClick={handleFollow} className="btn-main">
+                        {followed ? 'Unfollow' : 'Follow'}
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -55,7 +135,9 @@ const Author = () => {
 
               <div className="col-md-12">
                 <div className="de_tab tab_simple">
-                  <AuthorItems />
+                  {authorData && 
+                  <AuthorItems data={authorData?.nftCollection} loading={loading} authorImage={authorData?.authorImage} authorId={authorData?.authorId} />
+                  }
                 </div>
               </div>
             </div>
@@ -63,6 +145,7 @@ const Author = () => {
         </section>
       </div>
     </div>
+    
   );
 };
 

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import AuthorBanner from "../images/author_banner.jpg";
 import AuthorItems from "../components/author/AuthorItems";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import Skeleton from "../components/UI/Skeleton";
 
@@ -11,6 +11,7 @@ const Author = () => {
   const [loading, setLoading] = useState(true);
   const [followed, setFollowed] = useState(false);
   useEffect(() => {
+    window.scrollTo(0, 0)
     try {
       setLoading(true)
       const searchString = `https://us-central1-nft-cloud-functions.cloudfunctions.net/authors?author=${id}`
@@ -27,7 +28,6 @@ const Author = () => {
 
   function handleFollow() {
     setFollowed((prev) => {
-      console.log(!prev)
       return !prev;
     })
     

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,11 +1,9 @@
-import React, { useEffect } from "react";
+import React from "react";
 import SubHeader from "../images/subheader.jpg";
 import ExploreItems from "../components/explore/ExploreItems";
 
 const Explore = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
+  
 
   return (
     <div id="wrapper">
@@ -32,7 +30,7 @@ const Explore = () => {
         <section aria-label="section">
           <div className="container">
             <div className="row">
-              <ExploreItems />
+              <ExploreItems/>
             </div>
           </div>
         </section>

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -14,10 +14,11 @@ const Explore = () => {
           id="subheader"
           className="text-light"
           style={{ background: `url("${SubHeader}") top` }}
+          data-aos="fade-down" data-aos-duration='1000' data-aos-delay="50"
         >
-          <div className="center-y relative text-center">
+          <div className="center-y relative text-center" >
             <div className="container">
-              <div className="row">
+              <div className="row" >
                 <div className="col-md-12 text-center">
                   <h1>Explore</h1>
                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,19 +10,20 @@ import { debounce } from "lodash";
 
 
 const Home = () => {
-  const [hotCollectionsArray, setHotCollectionsArray] = useState()
-  const [hotCollectionsItems, setHotCollectionsItems] = useState(4)
+  const [hotCollectionsArray, setHotCollectionsArray] = useState();
+  const [newItemsArray, setNewItemsArray] = useState();
+  const [shownItems, setShownItems] = useState(4)
   useEffect(() => {
     window.scrollTo(0, 0);
     const handleResize = debounce(() => {
       if (window.innerWidth > 1024) {
-        setHotCollectionsItems(4)
+        setShownItems(4)
       } else if (window.innerWidth > 768) {
-        setHotCollectionsItems(3)
+        setShownItems(3)
       } else if (window.innerWidth > 576) {
-        setHotCollectionsItems(2)
+        setShownItems(2)
       } else {
-        setHotCollectionsItems(1)
+        setShownItems(1)
       }
     }, 200)
 
@@ -31,6 +32,8 @@ const Home = () => {
       async function fetchData() {
         const hotCollectionsData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/hotCollections')
         setHotCollectionsArray(hotCollectionsData.data)
+        const newItemsData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/newItems')
+        setNewItemsArray(newItemsData.data)
       }
       fetchData();
     } catch (error) {
@@ -40,7 +43,7 @@ const Home = () => {
       window.removeEventListener('resize', handleResize)
     }
 
-  }, [hotCollectionsItems]);
+  }, [shownItems]);
 
   return (
     <div id="wrapper">
@@ -49,9 +52,9 @@ const Home = () => {
         <Landing />
         <LandingIntro />
         {hotCollectionsArray  && 
-          <HotCollections data={hotCollectionsArray} items={hotCollectionsItems} />
+          <HotCollections data={hotCollectionsArray} items={shownItems} />
         }
-        <NewItems />
+        <NewItems data={newItemsArray} items={shownItems} />
         <TopSellers />
         <BrowseByCategory />
       </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import NewItems from "../components/home/NewItems";
 import TopSellers from "../components/home/TopSellers";
 import axios from "axios";
 import { debounce } from "lodash";
+import { useNavigate } from "react-router-dom";
 
 
 const Home = () => {
@@ -14,8 +15,10 @@ const Home = () => {
   const [newItemsArray, setNewItemsArray] = useState();
   const [topSellersArray, setTopSellersArray] = useState();
   const [shownItems, setShownItems] = useState(4)
+  const navigate = useNavigate()
   useEffect(() => {
     window.scrollTo(0, 0);
+    navigate('/')
     const handleResize = debounce(() => {
       if (window.innerWidth > 1024) {
         setShownItems(4)

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,15 +1,46 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import BrowseByCategory from "../components/home/BrowseByCategory";
 import HotCollections from "../components/home/HotCollections";
 import Landing from "../components/home/Landing";
 import LandingIntro from "../components/home/LandingIntro";
 import NewItems from "../components/home/NewItems";
 import TopSellers from "../components/home/TopSellers";
+import axios from "axios";
+import { debounce } from "lodash";
+
 
 const Home = () => {
+  const [hotCollectionsArray, setHotCollectionsArray] = useState()
+  const [hotCollectionsItems, setHotCollectionsItems] = useState(4)
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+    const handleResize = debounce(() => {
+      if (window.innerWidth > 1024) {
+        setHotCollectionsItems(4)
+      } else if (window.innerWidth > 768) {
+        setHotCollectionsItems(3)
+      } else if (window.innerWidth > 576) {
+        setHotCollectionsItems(2)
+      } else {
+        setHotCollectionsItems(1)
+      }
+    }, 200)
+
+    window.addEventListener('resize', handleResize)
+    try {
+      async function fetchData() {
+        const hotCollectionsData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/hotCollections')
+        setHotCollectionsArray(hotCollectionsData.data)
+      }
+      fetchData();
+    } catch (error) {
+      console.log('[HOT_COLLECTIONS_FETCH_ERROR]: ', error)
+    }
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+
+  }, [hotCollectionsItems]);
 
   return (
     <div id="wrapper">
@@ -17,7 +48,9 @@ const Home = () => {
         <div id="top"></div>
         <Landing />
         <LandingIntro />
-        <HotCollections />
+        {hotCollectionsArray  && 
+          <HotCollections data={hotCollectionsArray} items={hotCollectionsItems} />
+        }
         <NewItems />
         <TopSellers />
         <BrowseByCategory />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,6 +12,7 @@ import { debounce } from "lodash";
 const Home = () => {
   const [hotCollectionsArray, setHotCollectionsArray] = useState();
   const [newItemsArray, setNewItemsArray] = useState();
+  const [topSellersArray, setTopSellersArray] = useState();
   const [shownItems, setShownItems] = useState(4)
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -34,6 +35,8 @@ const Home = () => {
         setHotCollectionsArray(hotCollectionsData.data)
         const newItemsData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/newItems')
         setNewItemsArray(newItemsData.data)
+        const topSellersData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers')
+        setTopSellersArray(topSellersData.data)
       }
       fetchData();
     } catch (error) {
@@ -55,7 +58,7 @@ const Home = () => {
           <HotCollections data={hotCollectionsArray} items={shownItems} />
         }
         <NewItems data={newItemsArray} items={shownItems} />
-        <TopSellers />
+        <TopSellers data={topSellersArray} />
         <BrowseByCategory />
       </div>
     </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,9 +8,11 @@ import TopSellers from "../components/home/TopSellers";
 import axios from "axios";
 import { debounce } from "lodash";
 import { useNavigate } from "react-router-dom";
+import Aos from "aos";
 
 
 const Home = () => {
+  Aos.init();
   const [hotCollectionsArray, setHotCollectionsArray] = useState();
   const [newItemsArray, setNewItemsArray] = useState();
   const [topSellersArray, setTopSellersArray] = useState();
@@ -49,7 +51,7 @@ const Home = () => {
       window.removeEventListener('resize', handleResize)
     }
 
-  }, [shownItems]);
+  }, [shownItems, navigate]);
 
   return (
     <div id="wrapper">

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -3,8 +3,11 @@ import EthImage from "../images/ethereum.svg";
 import { Link, useParams } from "react-router-dom";
 import axios from "axios";
 import Skeleton from '../components/UI/Skeleton'
+import Aos from 'aos';
+import 'aos/dist/aos.css'; 
 
 const ItemDetails = () => {
+  Aos.init();
   const [itemData, setItemData] = useState()
   const [loading, setLoading] = useState(true)
   const [liked, setLiked] = useState(false)
@@ -40,7 +43,7 @@ const ItemDetails = () => {
     })
   }
 
-  if (loading) {
+  if (loading || !itemData) {
     return (
       <div id="wrapper">
       <div className="no-bottom no-top" id="content">
@@ -48,16 +51,16 @@ const ItemDetails = () => {
         <section aria-label="section" className="mt90 sm-mt-0">
           <div className="container">
             <div className="row">
-              <div className="col-md-6 text-center">
+              <div className="col-md-6 text-center"  data-aos='fade-right' data-aos-delay='100' data-aos-duration='1000'>
                 <Skeleton height={'100%'} width={'100%'} borderRadius={'0'} />
               </div>
-              <div className="col-md-6">
+              <div className="col-md-6" >
                 <div className="item_info">
-                  <Skeleton height={'2rem'} width={'25rem'} borderRadius={'0'} />
+                  <Skeleton height={'2rem'} width={'25rem'} borderRadius={'0'}  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000' />
 
                   <div className="item_info_counts">
-                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'} />
-                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'} />
+                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'}  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000' />
+                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'}  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000' />
                   </div>
                   <Skeleton height={'5rem'} width={'40rem'} borderRadius={'0'} />
                   <div className="d-flex flex-row">
@@ -109,7 +112,7 @@ const ItemDetails = () => {
         <section aria-label="section" className="mt90 sm-mt-0">
           <div className="container">
             <div className="row">
-              <div className="col-md-6 text-center">
+              <div className="col-md-6 text-center" data-aos='fade-right' data-aos-delay='100' data-aos-duration='1000'>
                 <img
                   src={itemData?.nftImage}
                   className="img-fluid img-rounded mb-sm-30 nft-image"
@@ -118,58 +121,60 @@ const ItemDetails = () => {
               </div>
               <div className="col-md-6">
                 <div className="item_info">
-                  <h2>{`${itemData?.title} #${itemData?.tag}`}</h2>
+                  <h2  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000'>{`${itemData?.title} #${itemData?.tag}`}</h2>
 
                   <div className="item_info_counts">
-                    <div className="item_info_views">
+                    <div className="item_info_views"  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000'>
                       <i className="fa fa-eye"></i>
                       {itemData?.views}
                     </div>
-                    <div id="like-button" className="item_info_like" onClick={handleLike}>
+                    <div id="like-button" className="item_info_like" onClick={handleLike}  data-aos='fade-down' data-aos-delay='100' data-aos-duration='1000'>
                       <i id='like-heart' className="fa fa-heart"></i>
                       {liked ? itemData?.likes + 1 : itemData?.likes}
                     </div>
                   </div>
-                  <p>
+                  <p   data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000'>
                     {itemData?.description}
                   </p>
                   <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
+                    <div className="mr40"  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' >
+                      <h6 data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000'>Owner</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
                           <Link to={`/author/${itemData?.ownerId}`}>
-                            <img className="lazy" src={itemData?.ownerImage} alt="" />
-                            <i className="fa fa-check"></i>
+                            <img className="lazy" src={itemData?.ownerImage} alt=""  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' />
+                            <i className="fa fa-check"  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' />
                           </Link>
                         </div>
-                        <div className="author_list_info">
-                          <Link to={`/author/${itemData?.ownerId}`}>{itemData?.ownerName}</Link>
+                        <div className="author_list_info"  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000'>
+                          <Link to={`/author/${itemData?.ownerId}`}  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' ><div  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000'>{itemData?.ownerName}</div></Link>
                         </div>
                       </div>
                     </div>
                     <div></div>
                   </div>
                   <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
+                    <div className="de_tab_content"  >
+                      <h6 data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000'>Creator</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
                           <Link to={`/author/${itemData?.creatorId}`}>
-                            <img className="lazy" src={itemData?.creatorImage} alt="" />
-                            <i className="fa fa-check"></i>
+                            <img className="lazy" src={itemData?.creatorImage} alt=""  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' />
+                            <i className="fa fa-check"  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' ></i>
                           </Link>
                         </div>
                         <div className="author_list_info">
-                          <Link to={`/author/${itemData?.creatorId}`}>{itemData?.creatorName}</Link>
+                          <Link to={`/author/${itemData?.creatorId}`}><div  data-aos='fade-left' data-aos-delay='100' data-aos-duration='1000' >{itemData?.creatorName}</div></Link>
                         </div>
                       </div>
                     </div>
                     <div className="spacer-40"></div>
                     <h6>Price</h6>
                     <div className="nft-item-price">
+                      <div  data-aos='fade-up' data-aos-delay='100' data-aos-duration='1000'  >
                       <img src={EthImage} alt="ETH" />
-                      <span>{itemData?.price}</span>
+                      <span >{itemData?.price}</span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,59 +1,74 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
-import nftImage from "../images/nftImage.jpg";
+import { Link, useParams } from "react-router-dom";
+import axios from "axios";
+import Skeleton from '../components/UI/Skeleton'
 
 const ItemDetails = () => {
+  const [itemData, setItemData] = useState()
+  const [loading, setLoading] = useState(true)
+  const [liked, setLiked] = useState(false)
+  const { id } = useParams();
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+    try {
+      setLoading(true)
+      const searchString = `https://us-central1-nft-cloud-functions.cloudfunctions.net/itemDetails?nftId=${id}`
+      async function fetchData() {
+        const result = await axios.get(searchString)
+        setItemData(result.data)
+      }
+      fetchData();
+      setLoading(false);
+    } catch (error) {
+      console.log('[FETCH_ITEM_DETAILS_ERROR]: ', error)
+    }
+  }, [id]);
 
-  return (
-    <div id="wrapper">
+  function handleLike () {
+    const likeButton = document.getElementById('like-button')
+    const likeHeart = document.getElementById('like-heart')
+    setLiked((prev) => {
+      if (prev) {
+        likeButton?.classList.remove('item-liked');
+        likeHeart?.classList.remove('item-liked-heart');
+      } else {
+        likeButton?.classList.add('item-liked')
+        likeHeart?.classList.add('item-liked-heart')
+      }
+      return !prev
+    })
+  }
+
+  if (loading) {
+    return (
+      <div id="wrapper">
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>
         <section aria-label="section" className="mt90 sm-mt-0">
           <div className="container">
             <div className="row">
               <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
+                <Skeleton height={'100%'} width={'100%'} borderRadius={'0'} />
               </div>
               <div className="col-md-6">
                 <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+                  <Skeleton height={'2rem'} width={'25rem'} borderRadius={'0'} />
 
                   <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
-                    </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
+                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'} />
+                      <Skeleton height={'1.5rem'} width={'2rem'} borderRadius={'0'} />
                   </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
+                  <Skeleton height={'5rem'} width={'40rem'} borderRadius={'0'} />
                   <div className="d-flex flex-row">
                     <div className="mr40">
                       <h6>Owner</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                          <Skeleton height={'3.2rem'} width={'3.2rem'} borderRadius={'50%'} />
                         </div>
                         <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                          <Skeleton height={'1.2rem'} width={'8rem'} borderRadius={'0'} />
                         </div>
                       </div>
                     </div>
@@ -64,21 +79,97 @@ const ItemDetails = () => {
                       <h6>Creator</h6>
                       <div className="item_author">
                         <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                          <Skeleton height={'3.2rem'} width={'3.2rem'} borderRadius={'50%'} />
                         </div>
                         <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                          <Skeleton height={'1.2rem'} width={'8rem'} borderRadius={'0'} />
                         </div>
                       </div>
                     </div>
                     <div className="spacer-40"></div>
                     <h6>Price</h6>
                     <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
+                      <Skeleton height={'2rem'} width={'5rem'} borderRadius={'0'} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    )
+  }
+
+  return (
+    <div id="wrapper">
+      <div className="no-bottom no-top" id="content">
+        <div id="top"></div>
+        <section aria-label="section" className="mt90 sm-mt-0">
+          <div className="container">
+            <div className="row">
+              <div className="col-md-6 text-center">
+                <img
+                  src={itemData?.nftImage}
+                  className="img-fluid img-rounded mb-sm-30 nft-image"
+                  alt=""
+                />
+              </div>
+              <div className="col-md-6">
+                <div className="item_info">
+                  <h2>{`${itemData?.title} #${itemData?.tag}`}</h2>
+
+                  <div className="item_info_counts">
+                    <div className="item_info_views">
+                      <i className="fa fa-eye"></i>
+                      {itemData?.views}
+                    </div>
+                    <div id="like-button" className="item_info_like" onClick={handleLike}>
+                      <i id='like-heart' className="fa fa-heart"></i>
+                      {liked ? itemData?.likes + 1 : itemData?.likes}
+                    </div>
+                  </div>
+                  <p>
+                    {itemData?.description}
+                  </p>
+                  <div className="d-flex flex-row">
+                    <div className="mr40">
+                      <h6>Owner</h6>
+                      <div className="item_author">
+                        <div className="author_list_pp">
+                          <Link to={`/author/${itemData?.ownerId}`}>
+                            <img className="lazy" src={itemData?.ownerImage} alt="" />
+                            <i className="fa fa-check"></i>
+                          </Link>
+                        </div>
+                        <div className="author_list_info">
+                          <Link to={`/author/${itemData?.ownerId}`}>{itemData?.ownerName}</Link>
+                        </div>
+                      </div>
+                    </div>
+                    <div></div>
+                  </div>
+                  <div className="de_tab tab_simple">
+                    <div className="de_tab_content">
+                      <h6>Creator</h6>
+                      <div className="item_author">
+                        <div className="author_list_pp">
+                          <Link to={`/author/${itemData?.creatorId}`}>
+                            <img className="lazy" src={itemData?.creatorImage} alt="" />
+                            <i className="fa fa-check"></i>
+                          </Link>
+                        </div>
+                        <div className="author_list_info">
+                          <Link to={`/author/${itemData?.creatorId}`}>{itemData?.creatorName}</Link>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="spacer-40"></div>
+                    <h6>Price</h6>
+                    <div className="nft-item-price">
+                      <img src={EthImage} alt="ETH" />
+                      <span>{itemData?.price}</span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
**Task:**

Fix broken repository link in git bash
Modify animation timings and trigger points for TopSellers component

**Why:**

Can't fix anything if i can't pull
Smoothen out animations so user has a more pleasant experience

**How:**

By leveraging modulo operations, numerical inversions, and the unique indexing order of the TopSellers component, I was able to make it so that each line horizontally animates in together, despite their indices being separated by 2 on every step. To do this, I took the step time I wanted each part of the animation to take and multiplied that by the equation (i % 3) / 1, where i is the index of the element being animated. This allows for indexes 0, 3, 6, and 9 to animate together, as well as 1, 4, 7, and 10, and the group 2, 5, 8, and 11 last. Utilizing this logic, the items seem to slide up the page into their resting place uniformly and smoothly.