### PR TITLE
feat(top-sellers): integrate Top Sellers API, clickable author links, and skeleton loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,16 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^0.27.2",
+        "axios": "^1.12.2",
         "firebase": "^9.8.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
-        "react-owl-carousel": "^2.3.3",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
-        "web-vitals": "^2.1.4",
-        "wowjs": "^1.1.3"
+        "react-slick": "^0.31.0",
+        "slick-carousel": "^1.8.1",
+        "web-vitals": "^2.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4828,11 +4828,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5054,21 +5049,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -5603,6 +5603,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5755,6 +5768,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clean-css": {
       "version": "5.2.4",
@@ -6869,6 +6888,20 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6999,10 +7032,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -8124,15 +8202,16 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -8376,9 +8455,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -8402,13 +8485,24 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8425,6 +8519,19 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -8550,6 +8657,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -8607,9 +8726,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8618,17 +8738,30 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -11153,9 +11286,11 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -11254,6 +11389,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -11560,6 +11704,15 @@
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -12152,14 +12305,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "dependencies": {
-        "jquery": ">=1.8.3"
       }
     },
     "node_modules/p-limit": {
@@ -13679,6 +13824,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -13975,56 +14126,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "dependencies": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "peerDependencies": {
-        "jquery": ">=1.8.3",
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14143,6 +14244,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-slick": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.31.0.tgz",
+      "integrity": "sha512-zo6VLT8wuSBJffg/TFPbzrw2dEnfZ/cUKmYsKByh3AgatRv29m2LoFbq5vRMa3R3A4wp4d8gwbJKO2fWZFaI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -14343,6 +14460,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -14883,6 +15006,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -15062,6 +15194,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -16796,14 +16934,6 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.1"
-      }
-    },
-    "node_modules/wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "dependencies": {
-        "animate.css": "latest"
       }
     },
     "node_modules/wrap-ansi": {
@@ -20455,11 +20585,6 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
-    "animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -20611,21 +20736,24 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       },
       "dependencies": {
         "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
             "mime-types": "^2.1.12"
           }
         }
@@ -21044,6 +21172,15 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -21153,6 +21290,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "clean-css": {
       "version": "5.2.4",
@@ -21973,6 +22115,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -22073,10 +22225,39 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
     "es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -22907,9 +23088,9 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -23066,9 +23247,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -23086,13 +23267,20 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -23104,6 +23292,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -23191,6 +23388,11 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -23233,16 +23435,24 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -25047,9 +25257,10 @@
       }
     },
     "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -25128,6 +25339,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
     },
     "json5": {
       "version": "2.2.0",
@@ -25377,6 +25596,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "mdn-data": {
       "version": "2.0.4",
@@ -25796,14 +26020,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
-      }
-    },
-    "owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "requires": {
-        "jquery": ">=1.8.3"
       }
     },
     "p-limit": {
@@ -26795,6 +27011,11 @@
         }
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -27006,48 +27227,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "requires": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -27143,6 +27322,17 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-slick": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.31.0.tgz",
+      "integrity": "sha512-zo6VLT8wuSBJffg/TFPbzrw2dEnfZ/cUKmYsKByh3AgatRv29m2LoFbq5vRMa3R3A4wp4d8gwbJKO2fWZFaI3g==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "readable-stream": {
@@ -27299,6 +27489,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -27690,6 +27885,12 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
+    "slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "requires": {}
+    },
     "sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -27829,6 +28030,11 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -29148,14 +29354,6 @@
       "requires": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.1"
-      }
-    },
-    "wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "requires": {
-        "animate.css": "latest"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.12.2",
     "firebase": "^9.8.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
+    "react-slick": "^0.31.0",
+    "slick-carousel": "^1.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
-        <Route path="/author" element={<Author />} />
+        <Route path="/author/:id" element={<Author />} />
         <Route path="/item-details" element={<ItemDetails />} />
       </Routes>
       <Footer />

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 import nftImage from "../../images/nftImage.jpg";
 
-const AuthorItems = () => {
+const AuthorItems = ({ authorId }) => {
   return (
     <div className="de_tab_content">
       <div className="tab-1">

--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -1,42 +1,180 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import Slider from "react-slick";
+import { fetchHotCollections } from "../../lib/api";
+
+
+const arrowBtn = {
+  position: "absolute",
+  top: "50%",
+  transform: "translateY(-50%)",
+  width: 44,
+  height: 44,
+  borderRadius: 9999,
+  background: "#fff",
+  border: "none",
+  boxShadow: "0 2px 8px rgba(0,0,0,.12)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 5,
+  cursor: "pointer",
+  outline: "none",
+};
+
+const ChevronLeft = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M15 19L8 12l7-7"
+      stroke="#232323"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+const ChevronRight = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M9 5l7 7-7 7"
+      stroke="#232323"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const NextArrow = ({ onClick, className }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={className}
+    style={{ ...arrowBtn, right: -22 }}
+  >
+    <ChevronRight />
+  </button>
+);
+const PrevArrow = ({ onClick, className }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={className}
+    style={{ ...arrowBtn, left: -22 }}
+  >
+    <ChevronLeft />
+  </button>
+);
 
 const HotCollections = () => {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true); 
+
+  useEffect(() => {
+    const c = new AbortController();
+    (async () => {
+      try {
+        const data = await fetchHotCollections(c.signal);
+        setItems(Array.isArray(data) ? data.slice(0, 6) : []);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => c.abort();
+  }, []);
+
+  const settings = {
+    infinite: true,
+    slidesToShow: 4,
+    slidesToScroll: 1,
+    speed: 400,
+    arrows: true,
+    dots: false,
+    nextArrow: <NextArrow />,
+    prevArrow: <PrevArrow />,
+    responsive: [
+      { breakpoint: 1200, settings: { slidesToShow: 3 } },
+      { breakpoint: 992, settings: { slidesToShow: 2 } },
+      { breakpoint: 576, settings: { slidesToShow: 1 } },
+    ],
+  };
+
   return (
     <section id="section-collections" className="no-bottom">
       <div className="container">
         <div className="row">
-          <div className="col-lg-12">
-            <div className="text-center">
-              <h2>Hot Collections</h2>
-              <div className="small-border bg-color-2"></div>
-            </div>
+          <div className="col-lg-12 text-center">
+            <h2>Hot Collections</h2>
+            <div className="small-border bg-color-2"></div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft_coll">
-                <div className="nft_wrap">
-                  <Link to="/item-details">
-                    <img src={nftImage} className="lazy img-fluid" alt="" />
-                  </Link>
-                </div>
-                <div className="nft_coll_pp">
-                  <Link to="/author">
-                    <img className="lazy pp-coll" src={AuthorImage} alt="" />
-                  </Link>
-                  <i className="fa fa-check"></i>
-                </div>
-                <div className="nft_coll_info">
-                  <Link to="/explore">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <span>ERC-192</span>
-                </div>
-              </div>
-            </div>
-          ))}
+
+          <div className="col-12">
+            {loading ? (
+              <Slider {...settings} className="hot-collections-slider">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={`sk-${i}`} className="slide-gutter">
+                    <div className="nft_coll">
+                      <div className="nft_wrap">
+                        <div className="sk sk-img" />
+                      </div>
+
+                      <div className="nft_coll_pp">
+                        <div className="sk sk-avatar" />
+                      </div>
+
+                      <div className="nft_coll_info">
+                        <div className="sk sk-title" />
+                        <div className="sk sk-sub" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </Slider>
+            ) : (
+              <Slider {...settings} className="hot-collections-slider">
+                {items.map((item, i) => {
+                  const id = item?.id ?? i;
+                  const img = item?.nftImage || item?.nft || item?.image;
+                  const authorImg = item?.authorImage || item?.author?.avatar;
+                  const title = item?.name || item?.title || "Untitled";
+                  const token = item?.code || item?.token || "ERC-192";
+                  return (
+                    <div key={id} className="slide-gutter">
+                      <div className="nft_coll">
+                        <div className="nft_wrap">
+                          <Link to={`/item-details/${id}`}>
+                            <img
+                              src={img}
+                              className="lazy img-fluid"
+                              alt={title}
+                            />
+                          </Link>
+                        </div>
+                        <div className="nft_coll_pp">
+                          <Link to={`/author/${item?.authorId || ""}`}>
+                            <img
+                              className="lazy pp-coll"
+                              src={authorImg}
+                              alt={title}
+                            />
+                          </Link>
+                          <i className="fa fa-check"></i>
+                        </div>
+                        <div className="nft_coll_info">
+                          <Link to="/explore">
+                            <h4>{title}</h4>
+                          </Link>
+                          <span>{token}</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </Slider>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,75 +1,276 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { fetchNewItems } from "../../lib/api";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 import nftImage from "../../images/nftImage.jpg";
+import Slider from "react-slick";
+
+function formatRemaining(ms) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const s = total % 60;
+  const m = Math.floor(total / 60) % 60;
+  const h = Math.floor(total / 3600); // total hours (can be > 24)
+  return `${h}h ${String(m).padStart(2, "0")}m ${String(s).padStart(2, "0")}s`;
+}
+
+/* component shows a ticking pill */
+function Countdown({ end }) {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (!end) {
+      setRemaining(0);
+      return;
+    }
+
+    const update = () => setRemaining(end - Date.now());
+    update(); 
+
+    const id = setInterval(() => {
+      const left = end - Date.now();
+      if (left <= 0) {
+        setRemaining(0);
+        clearInterval(id);
+      } else {
+        setRemaining(left);
+      }
+    }, 1000);
+
+    return () => clearInterval(id);
+  }, [end]);
+
+  if (!end) return null; // no pill if no expiry
+  if (remaining <= 0) return <div className="de_countdown">Ended</div>;
+  return <div className="de_countdown">{formatRemaining(remaining)}</div>;
+}
+
+const arrowBtn = {
+  position: "absolute",
+  top: "50%",
+  transform: "translateY(-50%)",
+  width: 44,
+  height: 44,
+  borderRadius: 9999,
+  background: "#fff",
+  border: "none",
+  boxShadow: "0 2px 8px rgba(0,0,0,.12)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 5,
+  cursor: "pointer",
+  outline: "none",
+};
+
+const ChevronLeft = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M15 19L8 12l7-7"
+      stroke="#232323"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+const ChevronRight = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M9 5l7 7-7 7"
+      stroke="#232323"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const NextArrow = ({ onClick, className }) => (
+  <button
+    type="button"
+    aria-label="Next"
+    onClick={onClick}
+    className={className}
+    style={{ ...arrowBtn, right: -22 }}
+  >
+    <ChevronRight />
+  </button>
+);
+
+const PrevArrow = ({ onClick, className }) => (
+  <button
+    type="button"
+    aria-label="Previous"
+    onClick={onClick}
+    className={className}
+    style={{ ...arrowBtn, left: -22 }}
+  >
+    <ChevronLeft />
+  </button>
+);
+
+// MAIN COMPONENT // 
 
 const NewItems = () => {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const settings = {
+    infinite: true,
+    slidesToShow: 4,
+    slidesToScroll: 1,
+    speed: 400,
+    arrows: true,
+    dots: false,
+    nextArrow: <NextArrow />,
+    prevArrow: <PrevArrow />,
+    responsive: [
+      { breakpoint: 1200, settings: { slidesToShow: 3 } },
+      { breakpoint: 992, settings: { slidesToShow: 2 } },
+      { breakpoint: 576, settings: { slidesToShow: 1 } },
+    ],
+    accessibility: true,
+    swipeToSlide: true,
+  };
+
+  useEffect(() => {
+    const c = new AbortController();
+    let alive = true;
+
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await fetchNewItems(c.signal);
+        if (!alive) return;
+        setItems(Array.isArray(data) ? data : []);
+      } catch (e) {
+        if (e?.name !== "AbortError") console.error(e);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+      c.abort();
+    };
+  }, []);
+
   return (
     <section id="section-items" className="no-bottom">
       <div className="container">
         <div className="row">
+          {/* header */}
           <div className="col-lg-12">
             <div className="text-center">
               <h2>New Items</h2>
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link
-                    to="/author"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="Creator: Monica Lucas"
-                  >
-                    <img className="lazy" src={AuthorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <div className="de_countdown">5h 30m 32s</div>
 
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
+          {/* content */}
+          <div className="col-12">
+            {loading ? (
+              <Slider {...settings} className="new-items-slider">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <div key={`sk-${index}`} className="slide-gutter">
+                    <div className="nft__item">
+                      <div className="author_list_pp">
+                        <span>
+                          <div className="sk sk-avatar" />
+                        </span>
+                      </div>
+                      <div className="nft__item_wrap">
+                        <div className="sk sk-img" />
+                      </div>
+
+                      <div className="nft__item_info">
+                        <div className="sk sk-title" />
+                        <div className="sk sk-sub" />
                       </div>
                     </div>
                   </div>
+                ))}
+              </Slider>
+            ) : (
+              <Slider {...settings} className="new-items-slider">
+                {items.slice(0, 6).map((item, index) => {
+                  const id = item?.id ?? index;
+                  const authorId = item?.authorId;
+                  const authorImg = item?.authorImage || AuthorImage;
+                  const img = item?.nftImage || nftImage;
+                  const nftId = item?.nftId ?? id;
+                  const title = item?.title || "Untitled";
+                  const price = item?.price != null ? `${item.price} ETH` : "";
+                  const likes = item?.likes ?? 0;
+                  const expires = item?.expiryDate;
 
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <div className="nft__item_price">3.08 ETH</div>
-                  <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>69</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
+                  return (
+                    <div key={id} className="slide-gutter">
+                      <div className="nft__item">
+                        <div className="author_list_pp">
+                          <Link
+                            to={`/author/${authorId || ""}`}
+                            title={`Creator: ${authorId || ""}`}
+                          >
+                            <img
+                              className="lazy"
+                              src={authorImg}
+                              alt={title}
+                              loading="lazy"
+                            />
+                            <i className="fa fa-check"></i>
+                          </Link>
+                        </div>
+
+                        {expires ? <Countdown end={expires} /> : null}
+
+                        <div className="nft__item_wrap">
+                          <div className="nft__item_extra">
+                            <div className="nft__item_buttons">
+                              <button>Buy Now</button>
+                              <div className="nft__item_share">
+                                <h4>Share</h4>
+                                <a href="#" onClick={(e) => e.preventDefault()}>
+                                  <i className="fa fa-facebook fa-lg"></i>
+                                </a>
+                                <a href="#" onClick={(e) => e.preventDefault()}>
+                                  <i className="fa fa-twitter fa-lg"></i>
+                                </a>
+                                <a href="#" onClick={(e) => e.preventDefault()}>
+                                  <i className="fa fa-envelope fa-lg"></i>
+                                </a>
+                              </div>
+                            </div>
+                          </div>
+
+                          <Link to={`/item-details/${nftId}`}>
+                            <img
+                              src={img}
+                              className="lazy nft__item_preview"
+                              alt={title}
+                              loading="lazy"
+                            />
+                          </Link>
+                        </div>
+
+                        <div className="nft__item_info">
+                          <Link to={`/item-details/${nftId}`}>
+                            <h4>{title}</h4>
+                          </Link>
+                          <div className="nft__item_price">{price}</div>
+                          <div className="nft__item_like">
+                            <i className="fa fa-heart"></i>
+                            <span>{likes}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </Slider>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,8 +1,63 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { fetchTopSellers } from "../../lib/api";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 
+const authorPath = (id) => `/author/${encodeURIComponent(id)}`;
+
+const SkeletonItem = ({ i }) => (
+  <li key={i} className="skeleton-li">
+    <div className="author_list_pp">
+      <div className="skeleton circle" style={{ width: 48, height: 48 }} />
+      <i className="fa fa-check"></i>
+    </div>
+    <div className="author_list_info" style={{ width: 120 }}>
+      <div className="skeleton bar" style={{ height: 12, marginBottom: 8 }} />
+      <div className="skeleton bar" style={{ height: 10, width: 60 }} />
+    </div>
+  </li>
+);
+
 const TopSellers = () => {
+  const [sellers, setSellers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => {
+    const c = new AbortController();
+    let alive = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setErr(null);
+        const data = await fetchTopSellers(c.signal);
+        if (!alive) return;
+
+        const normalized = (Array.isArray(data) ? data : []).map((x, i) => ({
+          id: String(x.id ?? x.authorId ?? i), // <- ensure we have an id
+          name: String(x.authorName ?? x.name ?? "Unknown"),
+          avatar: x.authorImage || x.avatar || x.image || AuthorImage,
+          priceEth:
+            x.priceEth != null
+              ? Number(x.priceEth)
+              : x.price != null
+              ? Number(x.price)
+              : Number(x.eth ?? 0),
+        }));
+
+        setSellers(normalized.slice(0, 12));
+      } catch (e) {
+        if (e?.name !== "AbortError") setErr("Could not load top sellers.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+      c.abort();
+    };
+  }, []);
+
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -13,26 +68,75 @@ const TopSellers = () => {
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
+
           <div className="col-md-12">
-            <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
-                    </Link>
-                  </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
-                  </div>
+            <ol
+              className={`author_list ${loading ? "loading" : ""}`}
+              aria-busy={loading ? "true" : "false"}
+              aria-live="polite"
+            >
+              {loading &&
+                Array.from({ length: 12 }).map((_, i) => (
+                  <li key={i}>
+                    <div className="ts-skel">
+                      <span className="ts-num">{i + 1}.</span>
+
+                      <div className="ts-avatar-wrap">
+                        <div className="sk ts-avatar" />
+                        <i
+                          className="fa fa-check ts-badge"
+                          aria-hidden="true"
+                        ></i>
+                      </div>
+
+                      <div className="ts-text">
+                        <div className="sk ts-line ts-w-28" />
+                        <div className="sk ts-line ts-w-16" />
+                      </div>
+                    </div>
+                  </li>
+                ))}
+
+              {!loading && err && (
+                <li
+                  className="text-center text-danger"
+                  style={{ listStyle: "none" }}
+                >
+                  {err}
                 </li>
-              ))}
+              )}
+
+              {!loading &&
+                !err &&
+                sellers.map((s, idx) => {
+                  const to = `/author/${encodeURIComponent(s.id)}`;
+                  return (
+                    <li key={s.id ?? idx}>
+                      <div className="author_list_pp">
+                        <Link to={to} state={{ seller: s }}>
+                          <img
+                            className="lazy pp-author"
+                            src={s.avatar || AuthorImage}
+                            alt={s.name}
+                            onError={(e) => (e.currentTarget.src = AuthorImage)}
+                          />
+                          <i className="fa fa-check"></i>
+                        </Link>
+                      </div>
+
+                      <div className="author_list_info">
+                        <Link to={to} state={{ seller: s }}>
+                          {s.name}
+                        </Link>
+                        <span>
+                          {Number.isFinite(s.priceEth)
+                            ? `${s.priceEth} ETH`
+                            : "—"}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                })}
             </ol>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -149,3 +149,61 @@
 
 #section-items .sk-title { width: 58%; }  
 #section-items .sk-sub   { width: 36%; }
+
+/* ── Top Sellers skeleton ─────────────────────────────────────────── */
+#section-popular ol.author_list.loading{
+  display:grid!important;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  column-gap:30px;
+  row-gap:18px;
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+#section-popular ol.author_list.loading>li{
+  list-style:none!important;
+  float:none!important;
+  width:auto!important;
+  padding:0!important;
+  margin:0!important;
+}
+
+#section-popular .sk{
+  position:relative; overflow:hidden; background:#eee; border-radius:8px;
+}
+#section-popular .sk::after{
+  content:""; position:absolute; inset:0; transform:translateX(-100%);
+  background:linear-gradient(90deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.55) 50%,rgba(255,255,255,0) 100%);
+  animation:sk-shimmer 1.6s infinite;
+}
+
+#section-popular .ts-skel{ display:flex; align-items:center; gap:12px; min-height:56px; }
+
+#section-popular .ts-num{
+  color:#E5E5E5;          
+  font-size:14px;
+  width:28px;              
+  text-align:right;
+  margin-right:8px;
+}
+
+#section-popular .ts-avatar-wrap{ position:relative; }
+#section-popular .ts-avatar{ width:48px; height:48px; border-radius:9999px; }
+
+#section-popular .ts-badge{
+  position:absolute;
+  right:-4px;            
+  bottom:-2px;
+  width:16px; height:16px;
+  border-radius:9999px;
+  background:#8364e2;      
+  color:#fff; font-size:10px; line-height:16px;
+  text-align:center;
+  border:2px solid #fff;    
+}
+
+#section-popular .ts-text{ flex:1; }
+#section-popular .ts-line{ height:12px; border-radius:6px; margin-bottom:6px; }
+#section-popular .ts-line:last-child{ height:10px; margin-bottom:0; opacity:.95; }
+#section-popular .ts-w-28{ width:112px; }  
+#section-popular .ts-w-16{ width:64px; } 

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,53 @@
 @import "./css/styles/style.css";
 @import "./css/colors/scheme-01.css";
 @import "./css/styles/coloring.css";
+
+#section-collections .hot-collections-slider .slick-list {
+  margin: 0 -1.5px; 
+}
+#section-collections .hot-collections-slider .slick-slide > div,
+#section-collections .hot-collections-slider .slide-gutter {
+  padding: 0 1.5px; 
+}
+
+#section-collections .hot-collections-slider .slick-prev:before,
+#section-collections .hot-collections-slider .slick-next:before {
+  content: none !important;
+}
+#section-collections .hot-collections-slider .slick-prev,
+#section-collections .hot-collections-slider .slick-next {
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+  box-sizing: border-box;
+}
+
+#section-collections .sk,
+#section-collections .skeleton-box {
+  position: relative;
+  overflow: hidden;
+  background: #eee;
+  border-radius: 8px;
+}
+#section-collections .sk::after,
+#section-collections .skeleton-box::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255,255,255,0) 0%,
+    rgba(255,255,255,.55) 50%,
+    rgba(255,255,255,0) 100%
+  );
+  animation: sk-shimmer 1.6s infinite;
+}
+@keyframes sk-shimmer { to { transform: translateX(100%); } }
+
+#section-collections .sk-img       { width: 100%; aspect-ratio: 16/10; border-radius: 12px 12px 0 0; }
+#section-collections .sk-avatar    { width: 52px; height: 52px; border-radius: 9999px; margin-top: -26px; border: 4px solid #fff; }
+#section-collections .sk-title     { height: 16px; width: 60%; margin: 10px auto 8px;  border-radius: 6px; }
+#section-collections .sk-sub       { height: 12px; width: 40%; margin: 0 auto 12px;   border-radius: 6px; opacity: .9; }

--- a/src/index.css
+++ b/src/index.css
@@ -11,20 +11,33 @@
 @import "./css/colors/scheme-01.css";
 @import "./css/styles/coloring.css";
 
-#section-collections .hot-collections-slider .slick-list {
-  margin: 0 -1.5px; 
+:root {
+  --slider-gutter: 1.5px;  
+}
+
+#section-collections .hot-collections-slider .slick-list,
+#section-items .new-items-slider .slick-list {
+  margin: 0 calc(var(--slider-gutter) * -1);
 }
 #section-collections .hot-collections-slider .slick-slide > div,
-#section-collections .hot-collections-slider .slide-gutter {
-  padding: 0 1.5px; 
+#section-collections .hot-collections-slider .slide-gutter,
+#section-items .new-items-slider .slick-slide > div,
+#section-items .new-items-slider .slide-gutter {
+  padding: 0 var(--slider-gutter);
 }
 
 #section-collections .hot-collections-slider .slick-prev:before,
-#section-collections .hot-collections-slider .slick-next:before {
+#section-collections .hot-collections-slider .slick-next:before,
+#section-items .new-items-slider .slick-prev:before,
+#section-items .new-items-slider .slick-next:before {
   content: none !important;
 }
+
+/* Keep arrow buttons centered inside the round circle */
 #section-collections .hot-collections-slider .slick-prev,
-#section-collections .hot-collections-slider .slick-next {
+#section-collections .hot-collections-slider .slick-next,
+#section-items .new-items-slider .slick-prev,
+#section-items .new-items-slider .slick-next {
   display: flex !important;
   align-items: center;
   justify-content: center;
@@ -33,30 +46,106 @@
   box-sizing: border-box;
 }
 
+
+#section-items .nft__item_wrap .nft__item_extra,
+#section-collections .nft__item_wrap .nft__item_extra {
+  opacity: 0 !important;
+  pointer-events: none;
+  transform: translateY(6px);
+  transition: none !important; 
+  z-index: 2;
+}
+#section-items .nft__item:hover .nft__item_wrap .nft__item_extra,
+#section-collections .nft__item:hover .nft__item_wrap .nft__item_extra {
+  opacity: 1 !important;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition: opacity .18s ease, transform .18s ease;
+}
+
+
 #section-collections .sk,
-#section-collections .skeleton-box {
+#section-items .sk,
+#section-collections .skeleton-box,
+#section-items .skeleton-box {
   position: relative;
   overflow: hidden;
   background: #eee;
   border-radius: 8px;
 }
 #section-collections .sk::after,
-#section-collections .skeleton-box::after {
+#section-items .sk::after,
+#section-collections .skeleton-box::after,
+#section-items .skeleton-box::after {
   content: "";
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
   background: linear-gradient(
     90deg,
-    rgba(255,255,255,0) 0%,
-    rgba(255,255,255,.55) 50%,
-    rgba(255,255,255,0) 100%
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.55) 50%,
+    rgba(255, 255, 255, 0) 100%
   );
   animation: sk-shimmer 1.6s infinite;
 }
 @keyframes sk-shimmer { to { transform: translateX(100%); } }
 
-#section-collections .sk-img       { width: 100%; aspect-ratio: 16/10; border-radius: 12px 12px 0 0; }
-#section-collections .sk-avatar    { width: 52px; height: 52px; border-radius: 9999px; margin-top: -26px; border: 4px solid #fff; }
-#section-collections .sk-title     { height: 16px; width: 60%; margin: 10px auto 8px;  border-radius: 6px; }
-#section-collections .sk-sub       { height: 12px; width: 40%; margin: 0 auto 12px;   border-radius: 6px; opacity: .9; }
+#section-collections .sk-img,
+#section-items .sk-img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: 12px 12px 0 0; 
+}
+#section-collections .sk-avatar,
+#section-items .sk-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 9999px;
+  margin-top: -26px;
+  border: 4px solid #fff;
+}
+#section-collections .sk-title,
+#section-items .sk-title {
+  height: 16px;
+  width: 60%;
+  margin: 10px auto 8px;
+  border-radius: 6px;
+}
+#section-collections .sk-sub,
+#section-items .sk-sub {
+  height: 12px;
+  width: 40%;
+  margin: 0 auto 12px;
+  border-radius: 6px;
+  opacity: .9;
+}
+
+#section-items .sk-img {
+  aspect-ratio: 4 / 3;   
+  border-radius: 12px;   
+}
+
+#section-items .sk-avatar {
+  margin-top: 0;         
+}
+
+#section-items .sk-title {
+  margin: 14px auto 8px;
+  width: 58%;
+}
+#section-items .sk-sub {
+  margin: 0 auto 14px;
+  width: 36%;
+}
+
+#section-items .nft__item_info { text-align: left; } 
+
+#section-items .sk-title,
+#section-items .sk-sub {
+  margin-left: 0;    
+  margin-right: 0;
+}
+
+#section-items .sk-title { width: 58%; }  
+#section-items .sk-sub   { width: 36%; }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -13,3 +13,8 @@ export async function fetchNewItems(signal) {
   const res = await http.get("newItems", { signal });
   return res.data || [];
 }
+
+export async function fetchTopSellers(signal) {
+    const res = await http.get("topSellers", { signal });
+    return res.data || [];
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+const http = axios.create({
+  baseURL: "https://us-central1-nft-cloud-functions.cloudfunctions.net/",
+});
+
+export async function fetchHotCollections(signal) {
+  const res = await http.get("hotCollections", { signal });
+  return res.data; 
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -8,3 +8,8 @@ export async function fetchHotCollections(signal) {
   const res = await http.get("hotCollections", { signal });
   return res.data; 
 }
+
+export async function fetchNewItems(signal) {
+  const res = await http.get("newItems", { signal });
+  return res.data || [];
+}

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -1,10 +1,84 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
 import AuthorBanner from "../images/author_banner.jpg";
 import AuthorItems from "../components/author/AuthorItems";
-import { Link } from "react-router-dom";
 import AuthorImage from "../images/author_thumbnail.jpg";
+import { fetchTopSellers } from "../lib/api";
 
-const Author = () => {
+export default function Author() {
+  const { id } = useParams(); 
+  const location = useLocation();
+  const passedSeller = location.state?.seller;
+
+  const [seller, setSeller] = useState(passedSeller || null);
+  const [loading, setLoading] = useState(!passedSeller);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => {
+    if (passedSeller) return; 
+    let alive = true;
+    const c = new AbortController();
+
+    (async () => {
+      try {
+        setLoading(true);
+        setErr(null);
+        const list = await fetchTopSellers(c.signal);
+        if (!alive) return;
+        const found = (Array.isArray(list) ? list : []).find(
+          (x) => String(x.id ?? x.authorId ?? x.uid) === String(id)
+        );
+        setSeller(
+          found
+            ? {
+                id: String(found.id ?? found.authorId ?? found.uid),
+                name: String(found.authorName ?? found.name ?? "Unknown"),
+                avatar:
+                  found.authorImage ||
+                  found.avatar ||
+                  found.image ||
+                  AuthorImage,
+                username: found.username || "@creator",
+                wallet:
+                  found.wallet ||
+                  "UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7",
+                followers: found.followers ?? 573,
+              }
+            : null
+        );
+      } catch (e) {
+        if (e?.name !== "AbortError") setErr("Could not load author.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+      c.abort();
+    };
+  }, [id, passedSeller]);
+
+  const view = useMemo(() => {
+    if (!seller) return null;
+    return {
+      id: seller.id,
+      name: seller.name ?? "Unknown",
+      avatar: seller.avatar || AuthorImage,
+      username: seller.username ?? "@creator",
+      wallet:
+        seller.wallet ??
+        "UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7",
+      followers: seller.followers ?? 573,
+    };
+  }, [seller]);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(view.wallet);
+    } catch {}
+  };
+
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
@@ -16,7 +90,7 @@ const Author = () => {
           className="text-light"
           data-bgimage="url(images/author_banner.jpg) top"
           style={{ background: `url(${AuthorBanner}) top` }}
-        ></section>
+        />
 
         <section aria-label="section">
           <div className="container">
@@ -25,26 +99,43 @@ const Author = () => {
                 <div className="d_profile de-flex">
                   <div className="de-flex-col">
                     <div className="profile_avatar">
-                      <img src={AuthorImage} alt="" />
-
+                      <img
+                        src={view?.avatar || AuthorImage}
+                        alt={view?.name || "Author"}
+                        onError={(e) => (e.currentTarget.src = AuthorImage)}
+                      />
                       <i className="fa fa-check"></i>
+
                       <div className="profile_name">
                         <h4>
-                          Monica Lucas
-                          <span className="profile_username">@monicaaaa</span>
-                          <span id="wallet" className="profile_wallet">
-                            UDHUHWudhwd78wdt7edb32uidbwyuidhg7wUHIFUHWewiqdj87dy7
-                          </span>
-                          <button id="btn_copy" title="Copy Text">
-                            Copy
-                          </button>
+                          {loading ? "Loading..." : view?.name}
+                          {!loading && (
+                            <>
+                              <span className="profile_username">
+                                {view.username}
+                              </span>
+                              <span id="wallet" className="profile_wallet">
+                                {view.wallet}
+                              </span>
+                              <button
+                                id="btn_copy"
+                                title="Copy Text"
+                                onClick={onCopy}
+                              >
+                                Copy
+                              </button>
+                            </>
+                          )}
                         </h4>
                       </div>
                     </div>
                   </div>
+
                   <div className="profile_follow de-flex">
                     <div className="de-flex-col">
-                      <div className="profile_follower">573 followers</div>
+                      <div className="profile_follower">
+                        {loading ? "…" : `${view.followers} followers`}
+                      </div>
                       <Link to="#" className="btn-main">
                         Follow
                       </Link>
@@ -55,15 +146,19 @@ const Author = () => {
 
               <div className="col-md-12">
                 <div className="de_tab tab_simple">
-                  <AuthorItems />
+                  <AuthorItems authorId={id} />
                 </div>
               </div>
+
+              {!loading && !view && (
+                <div className="col-md-12" style={{ color: "#e74c3c" }}>
+                  {err || "Author not found."}
+                </div>
+              )}
             </div>
           </div>
         </section>
       </div>
     </div>
   );
-};
-
-export default Author;
+}

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,6 +5,7 @@ import ExploreItems from "../components/explore/ExploreItems";
 const Explore = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
+    // does this work?
   }, []);
 
   return (


### PR DESCRIPTION
Task:
- Implement Top Sellers section with live API data
- Make each seller clickable → `/author/:id`
- Add a polished loading skeleton (3 columns, grey 1–12, shimmer, purple check)

Why:
- Improve UX with instant visual feedback (no layout jump)
- Enable quick navigation to author profiles
- Keep UI consistent with other homepage sections

How:
- `fetchTopSellers(signal)` in `lib/api.js`; normalize fields (id, name, avatar, priceEth)
- Links use `Link to={/author/${id}} state={{ seller }}` for fast author rendering
- `Author.jsx` reads router **state** and **falls back to fetch** by `:id` on hard refresh
- Skeleton CSS scoped to **`#section-popular`** (grid layout, grey numbers, shimmer via existing `sk-shimmer`)
- Accessibility: `aria-busy` on list; decorative elements `aria-hidden`