### PR TITLE
Feat: added NewItems NFT slider with countdown timers and skeleton st…

### DIFF
--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -119,16 +119,16 @@ const NewItems = () => {
                       key={index}
                     >
                       <div className="nft_item">
-                        <div style={{ ...skeletonStyle, height: "180px" }} />
                         <div
                           style={{
                             ...skeletonStyle,
-                            height: "40px",
-                            width: "40px",
+                            height: "50px",
+                            width: "50px",
                             borderRadius: "50%",
                             margin: "8px auto",
                           }}
                         />
+                        <div style={{ ...skeletonStyle, height: "180px" }} />
                         <div
                           style={{
                             ...skeletonStyle,

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,9 +1,87 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
+import axios from "axios";
+import { useEffect, useState } from "react";
 import nftImage from "../../images/nftImage.jpg";
+import { useKeenSlider } from "keen-slider/react";
+import "keen-slider/keen-slider.min.css";
+
+function DeCountdown({ endTime }) {
+  const [timeLeft, setTimeLeft] = useState(endTime - Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const remaining = endTime - Date.now();
+
+      if (remaining <= 0) {
+        setTimeLeft(0);
+        clearInterval(interval);
+        return;
+      }
+
+      setTimeLeft(remaining);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [endTime]);
+
+  const hours = Math.floor(timeLeft / (1000 * 60 * 60));
+  const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((timeLeft % (1000 * 60)) / 1000);
+
+  return (
+    <div>
+      {hours}h {minutes}m {seconds}s
+    </div>
+  );
+}
 
 const NewItems = () => {
+  const [items, setItems] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [sliderRef, instanceRef] = useKeenSlider({
+    loop: true,
+    slides: {
+      perView: 4,
+      spacing: 15,
+    },
+    breakpoints: {
+      "(max-width: 768px)": {
+        slides: {
+          perView: 2,
+          spacing: 10,
+        },
+      },
+      "(max-width: 480px)": {
+        slides: {
+          perView: 1,
+          spacing: 8,
+        },
+      },
+    },
+  });
+  const skeletonStyle = {
+    background: "linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 37%, #f0f0f0 63%)",
+    backgroundSize: "200% 100%",
+    animation: "shimmer 1.4s ease infinite",
+    borderRadius: "8px",
+  };
+  useEffect(() => {
+    instanceRef.current?.update();
+  }, [items, instanceRef]);
+
+  useEffect(() => {
+    axios
+      .get(
+        "https://us-central1-nft-cloud-functions.cloudfunctions.net/newItems",
+      )
+      .then((response) => {
+        setItems(response.data.slice(0, 8));
+        setLoading(false);
+      });
+  }, []);
+
   return (
     <section id="section-items" className="no-bottom">
       <div className="container">
@@ -14,62 +92,138 @@ const NewItems = () => {
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link
-                    to="/author"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="Creator: Monica Lucas"
-                  >
-                    <img className="lazy" src={AuthorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <div className="de_countdown">5h 30m 32s</div>
+          <div style={{ position: "relative" }}>
+            <button
+              onClick={() => instanceRef.current?.prev()}
+              className="arrow arrow-left"
+              style={{
+                position: "absolute",
+                left: "-20px",
+                top: "50%",
+                transform: "translateY(-50%)",
+                zIndex: 1,
+              }}
+            >
+              <i className="fa fa-angle-left"></i>
+            </button>
 
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
+            <div
+              ref={sliderRef}
+              className="keen-slider"
+              key={loading ? "loading" : "loaded"}
+            >
+              {loading
+                ? Array.from({ length: 4 }, (_, index) => (
+                    <div
+                      className="keen-slider__slide col-lg-3 col-md-6 col-sm-6 col-xs-12"
+                      key={index}
+                    >
+                      <div className="nft_item">
+                        <div style={{ ...skeletonStyle, height: "180px" }} />
+                        <div
+                          style={{
+                            ...skeletonStyle,
+                            height: "40px",
+                            width: "40px",
+                            borderRadius: "50%",
+                            margin: "8px auto",
+                          }}
+                        />
+                        <div
+                          style={{
+                            ...skeletonStyle,
+                            height: "16px",
+                            width: "60%",
+                            margin: "8px auto",
+                          }}
+                        />
                       </div>
                     </div>
-                  </div>
+                  ))
+                : items.map((item) => (
+                    <div
+                      className="keen-slider__slide col-lg-3 col-md-6 col-sm-6 col-xs-12"
+                      key={item.id}
+                    >
+                      <div className="nft__item">
+                        <div className="author_list_pp">
+                          <Link
+                            to="/author"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            title="Creator: Monica Lucas"
+                          >
+                            <img
+                              className="lazy"
+                              src={item.authorImage}
+                              alt=""
+                            />
+                            <i className="fa fa-check"></i>
+                          </Link>
+                        </div>
+                        {item.expiryDate && (
+                          <div className="de_countdown">
+                            <DeCountdown endTime={item.expiryDate} />
+                          </div>
+                        )}
 
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <div className="nft__item_price">3.08 ETH</div>
-                  <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>69</span>
-                  </div>
-                </div>
-              </div>
+                        <div className="nft__item_wrap">
+                          <div className="nft__item_extra">
+                            <div className="nft__item_buttons">
+                              <button>Buy Now</button>
+                              <div className="nft__item_share">
+                                <h4>Share</h4>
+                                <a href="" target="_blank" rel="noreferrer">
+                                  <i className="fa fa-facebook fa-lg"></i>
+                                </a>
+                                <a href="" target="_blank" rel="noreferrer">
+                                  <i className="fa fa-twitter fa-lg"></i>
+                                </a>
+                                <a href="">
+                                  <i className="fa fa-envelope fa-lg"></i>
+                                </a>
+                              </div>
+                            </div>
+                          </div>
+
+                          <Link to="/item-details">
+                            <img
+                              src={item.nftImage}
+                              className="lazy nft__item_preview"
+                              alt=""
+                            />
+                          </Link>
+                        </div>
+                        <div className="nft__item_info">
+                          <Link to="/item-details">
+                            <h4>{item.title}</h4>
+                          </Link>
+                          <div className="nft__item_price">
+                            {item.price} ETH
+                          </div>
+                          <div className="nft__item_like">
+                            <i className="fa fa-heart"></i>
+                            <span>69</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
             </div>
-          ))}
+            <button
+              onClick={() => instanceRef.current?.next()}
+              className="arrow arrow-right"
+              style={{
+                position: "absolute",
+                right: "-20px",
+                top: "50%",
+                transform: "translateY(-50%)",
+                zIndex: 1,
+              }}
+            >
+              <i className="fa fa-angle-right"></i>
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -1,8 +1,26 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
+import axios from "axios";
 
 const TopSellers = () => {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const skeletonStyle = {
+    background:
+      "linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 37%, #f0f0f0 63%)",
+    backgroundSize: "200% 100%",
+    animation: "shimmer 1.4s ease infinite",
+  };
+  useEffect(() => {
+    axios.get(
+      "https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers",
+    )
+      .then((response) => {
+        setItems(response.data);
+        setLoading(false);
+      });
+  }, []);
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -14,29 +32,37 @@ const TopSellers = () => {
             </div>
           </div>
           <div className="col-md-12">
-            <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
+        <ol className="author_list">
+           {loading
+            ? Array.from({ length: 12 }).map((_, index) => (
+                <li key={index} style={{ display: "flex", alignItems: "center" }}>
+                <div className="author_list_pp">
+                <div style={{ ...skeletonStyle, height: "50px", width: "50px", borderRadius: "50%", margin: "8px auto" }} />
+                </div>
+                <div className="author_list_info">
+                 <div style={{ ...skeletonStyle, height: "21px", width: "128.7px", margin: "8px auto" }} />
+                <div style={{ ...skeletonStyle, height: "16.7px", width: "50px", margin: "8px auto" }} />
+              </div>
+           </li>
+          ))
+          : items.map((seller) => (
+          <li key={seller.id}>
+          <div className="author_list_pp">
+                <Link to="/author">
+                  <img className="lazy pp-author" src={seller.authorImage} alt="" />
+                   <i className="fa fa-check"></i>
                     </Link>
-                  </div>
+                    </div>
                   <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
+                  <Link to="/author">{seller.authorName}</Link>
+                   <span>{seller.price} ETH</span>
                   </div>
                 </li>
-              ))}
+               ))}
             </ol>
+            </div>
           </div>
         </div>
-      </div>
     </section>
   );
 };

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -2613,7 +2613,7 @@ footer:not(.footer-light) #form_subscribe.form-dark input[type="text"] {
   font-family: "FontAwesome";
   font-size: 20px;
   content: "\f067";
-  color: #222;
+  color: #fff;
   position: relative;
   top: 12px;
   margin: 0 0 0 -8px;
@@ -2623,7 +2623,7 @@ footer:not(.footer-light) #form_subscribe.form-dark input[type="text"] {
   font-family: "FontAwesome";
   font-size: 20px;
   content: "\f068";
-  color: #222;
+  color: #fff;
   position: relative;
   top: -35px;
   margin: 0 0 0 -8px;
@@ -15279,6 +15279,24 @@ a.btn-slider:hover {
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
   border-right: 10px solid blue;
+}
+
+.arrow {
+  background: #ffffff;
+  border: soloid 0.5px #cccccc;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  color: #111111;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.arrow:hover {
+  background: #f0f0f0;
 }
 
 blockquote.very-big {


### PR DESCRIPTION
New Items
 feat: NewItems slider with Keen Slider, countdown timers, arrow buttons to control slider and skeleton loading state 

what it does 
   - fetches NFT items from an API and displays them in Keen Slider carousel
   - countdown timer component (DeCountdown) calculates the remaining time time from Unix get unix time stamp
   - skeleton loading state that displays while loading
   - responsive breakpoints: displays 4 cards in desktop, 2 in tablet, 1 in mobile
   - fwd/rev arrow control buttons. for slider navigation
   
countdown timer: using Unix it displays remaining time to a sale 
<img width="1792" height="1120" alt="pre add" src="https://github.com/user-attachments/assets/199208de-fe27-4881-9384-5cd317782868" />
<img width="1792" height="1120" alt="feat- finished" src="https://github.com/user-attachments/assets/389d72b6-9e13-4434-8a14-29d1bce6455e" />
