### PR TITLE
Dynamic Explore Items Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.npm-cache/
 .firebase/
 .firebaserc
 build/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,13 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^0.27.2",
         "firebase": "^9.8.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
-        "react-owl-carousel": "^2.3.3",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
-        "web-vitals": "^2.1.4",
-        "wowjs": "^1.1.3"
+        "web-vitals": "^2.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4828,11 +4825,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5051,28 +5043,6 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -11152,11 +11122,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12152,14 +12117,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "dependencies": {
-        "jquery": ">=1.8.3"
       }
     },
     "node_modules/p-limit": {
@@ -13974,56 +13931,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "dependencies": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "peerDependencies": {
-        "jquery": ">=1.8.3",
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-owl-carousel/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -16796,14 +16703,6 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.1"
-      }
-    },
-    "node_modules/wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "dependencies": {
-        "animate.css": "latest"
       }
     },
     "node_modules/wrap-ansi": {
@@ -20455,11 +20354,6 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
-    "animate.css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-      "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -20609,27 +20503,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -25046,11 +24919,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25796,14 +25664,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
-      }
-    },
-    "owl.carousel": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
-      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
-      "requires": {
-        "jquery": ">=1.8.3"
       }
     },
     "p-limit": {
@@ -27005,48 +26865,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-owl-carousel": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-owl-carousel/-/react-owl-carousel-2.3.3.tgz",
-      "integrity": "sha512-B4TI2EDDtp7IDM8CWzl5Rh/17p1NfMW/QBIbkC18CkiMGCbO9ztY+vAPTN60tp+63V9v/oLqArLjkiQtDGqj/A==",
-      "requires": {
-        "owl.carousel": "~2.3.4",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
     },
     "react-refresh": {
       "version": "0.11.0",
@@ -29148,14 +28966,6 @@
       "requires": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.1"
-      }
-    },
-    "wowjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "integrity": "sha1-RA/Bu0x+iWhA7keXIpaitZB1rL0=",
-      "requires": {
-        "animate.css": "latest"
       }
     },
     "wrap-ansi": {

--- a/src/components/common/NftCardSkeleton.jsx
+++ b/src/components/common/NftCardSkeleton.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import "./nft-card-skeleton.css";
+
+const NftCardSkeleton = () => {
+  return (
+    <div className="nft__item nft-card-skeleton" aria-hidden="true">
+      <div className="author_list_pp">
+        <span className="nft-card-skeleton__pulse nft-card-skeleton__avatar" />
+      </div>
+      <div className="de_countdown">
+        <span className="nft-card-skeleton__pulse nft-card-skeleton__countdown-inner" />
+      </div>
+      <div className="nft__item_wrap">
+        <span className="nft-card-skeleton__pulse nft-card-skeleton__preview" />
+      </div>
+      <div className="nft__item_info">
+        <span className="nft-card-skeleton__pulse nft-card-skeleton__bar--title" />
+        <div className="nft-card-skeleton__row">
+          <span className="nft-card-skeleton__pulse nft-card-skeleton__bar--price" />
+          <span className="nft-card-skeleton__pulse nft-card-skeleton__bar--like" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NftCardSkeleton;

--- a/src/components/common/nft-card-skeleton.css
+++ b/src/components/common/nft-card-skeleton.css
@@ -1,0 +1,69 @@
+.nft-card-skeleton {
+  pointer-events: none;
+}
+
+.nft-card-skeleton__pulse {
+  display: block;
+  background: #e8e8ea;
+  border-radius: 6px;
+  animation: nft-card-skeleton-pulse 1s ease-in-out infinite;
+}
+
+.dark-scheme .nft-card-skeleton__pulse {
+  background: #2a2a2f;
+}
+
+@keyframes nft-card-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.nft-card-skeleton__avatar.nft-card-skeleton__pulse {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+}
+
+.nft-card-skeleton__countdown-inner.nft-card-skeleton__pulse {
+  height: 18px;
+  width: 120px;
+  margin: 0 auto;
+}
+
+.nft-card-skeleton__preview.nft-card-skeleton__pulse {
+  width: 100%;
+  height: 220px;
+  border-radius: 8px;
+}
+
+.nft-card-skeleton__bar--title.nft-card-skeleton__pulse {
+  height: 20px;
+  width: 70%;
+  margin-bottom: 12px;
+}
+
+.nft-card-skeleton__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.nft-card-skeleton__bar--price.nft-card-skeleton__pulse {
+  height: 16px;
+  width: 40%;
+}
+
+.nft-card-skeleton__bar--like.nft-card-skeleton__pulse {
+  height: 16px;
+  width: 48px;
+}
+
+.nft-card-skeleton .nft__item_info {
+  padding-top: 4px;
+}

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,78 +1,129 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import React, { useEffect, useState } from "react";
+import NftCardSkeleton from "../common/NftCardSkeleton";
+import NftItemCard from "./NftItemCard";
+import {
+  getExploreListUrl,
+  SKELETON_MIN_MS,
+} from "../../constants/exploreApi";
+import { withMinDelay } from "../../utils/withMinDelay";
+
+const INITIAL_VISIBLE = 8;
+const LOAD_MORE_INCREMENT = 4;
 
 const ExploreItems = () => {
+  const [filter, setFilter] = useState("");
+  const [items, setItems] = useState([]);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await withMinDelay(
+          SKELETON_MIN_MS,
+          (async () => {
+            const res = await fetch(getExploreListUrl(filter));
+            if (!res.ok) {
+              throw new Error(`Request failed (${res.status})`);
+            }
+            const json = await res.json();
+            if (!Array.isArray(json)) {
+              throw new Error("Invalid response shape");
+            }
+            return json;
+          })()
+        );
+        if (cancelled) return;
+        setItems(data);
+        setVisibleCount(Math.min(INITIAL_VISIBLE, data.length));
+      } catch (e) {
+        if (!cancelled) {
+          setError(e.message || "Failed to load explore items");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [filter]);
+
+  const handleLoadMore = () => {
+    setVisibleCount((c) => Math.min(c + LOAD_MORE_INCREMENT, items.length));
+  };
+
+  const visibleItems = items.slice(0, visibleCount);
+  const canLoadMore = !loading && !error && visibleCount < items.length;
+
   return (
     <>
       <div>
-        <select id="filter-items" defaultValue="">
+        <select
+          id="filter-items"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        >
           <option value="">Default</option>
           <option value="price_low_to_high">Price, Low to High</option>
           <option value="price_high_to_low">Price, High to Low</option>
           <option value="likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
-            </div>
-            <div className="de_countdown">5h 30m 32s</div>
-
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
-            </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
+      {loading &&
+        Array.from({ length: INITIAL_VISIBLE }, (_, i) => (
+          <div
+            key={`skeleton-${i}`}
+            className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+            style={{ display: "block", backgroundSize: "cover" }}
+          >
+            <NftCardSkeleton />
           </div>
+        ))}
+      {error && (
+        <div className="col-md-12 text-center py-4 text-danger">{error}</div>
+      )}
+      {!loading &&
+        !error &&
+        visibleItems.map((item) => (
+          <div
+            key={item.id}
+            className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+            style={{ display: "block", backgroundSize: "cover" }}
+          >
+            <NftItemCard
+              authorImage={item.authorImage}
+              nftImage={item.nftImage}
+              title={item.title}
+              price={item.price}
+              likes={item.likes}
+              expiryDate={item.expiryDate}
+              nftId={item.nftId}
+              authorId={item.authorId}
+            />
+          </div>
+        ))}
+      {canLoadMore && (
+        <div className="col-md-12 text-center">
+          <button
+            type="button"
+            id="loadmore"
+            className="btn-main lead"
+            onClick={handleLoadMore}
+          >
+            Load more
+          </button>
         </div>
-      ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
-      </div>
+      )}
     </>
   );
 };

--- a/src/components/explore/NftItemCard.jsx
+++ b/src/components/explore/NftItemCard.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useCountdown } from "../../hooks/useCountdown";
+
+function formatPriceEth(price) {
+  const n = Number(price);
+  if (!Number.isFinite(n)) return "— ETH";
+  return `${n.toFixed(2)} ETH`;
+}
+
+const NftItemCard = ({
+  authorImage,
+  nftImage,
+  title,
+  price,
+  likes,
+  expiryDate,
+  nftId,
+  authorId,
+}) => {
+  const countdownLabel = useCountdown(expiryDate);
+  const authorLink = `/author?authorId=${encodeURIComponent(authorId)}`;
+  const itemLink = `/item-details?nftId=${encodeURIComponent(nftId)}`;
+  const priceText = formatPriceEth(price);
+
+  return (
+    <div className="nft__item">
+      <div className="author_list_pp">
+        <Link
+          to={authorLink}
+          data-bs-toggle="tooltip"
+          data-bs-placement="top"
+        >
+          <img className="lazy" src={authorImage} alt="" />
+          <i className="fa fa-check"></i>
+        </Link>
+      </div>
+      <div className="de_countdown">{countdownLabel}</div>
+
+      <div className="nft__item_wrap">
+        <div className="nft__item_extra">
+          <div className="nft__item_buttons">
+            <button type="button">Buy Now</button>
+            <div className="nft__item_share">
+              <h4>Share</h4>
+              <a href="" target="_blank" rel="noreferrer">
+                <i className="fa fa-facebook fa-lg"></i>
+              </a>
+              <a href="" target="_blank" rel="noreferrer">
+                <i className="fa fa-twitter fa-lg"></i>
+              </a>
+              <a href="">
+                <i className="fa fa-envelope fa-lg"></i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <Link to={itemLink}>
+          <img
+            src={nftImage}
+            className="lazy nft__item_preview"
+            alt={title || "NFT preview"}
+          />
+        </Link>
+      </div>
+      <div className="nft__item_info">
+        <Link to={itemLink}>
+          <h4>{title}</h4>
+        </Link>
+        <div className="nft__item_price">{priceText}</div>
+        <div className="nft__item_like">
+          <i className="fa fa-heart"></i>
+          <span>{likes}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NftItemCard;

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,9 +1,59 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import React, { useEffect, useState } from "react";
+import NftCardSkeleton from "../common/NftCardSkeleton";
+import NftItemCard from "../explore/NftItemCard";
+import {
+  EXPLORE_API_URL,
+  SKELETON_MIN_MS,
+} from "../../constants/exploreApi";
+import { withMinDelay } from "../../utils/withMinDelay";
+
+const HOME_NEW_ITEMS_COUNT = 4;
 
 const NewItems = () => {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await withMinDelay(
+          SKELETON_MIN_MS,
+          (async () => {
+            const res = await fetch(EXPLORE_API_URL);
+            if (!res.ok) {
+              throw new Error(`Request failed (${res.status})`);
+            }
+            const json = await res.json();
+            if (!Array.isArray(json)) {
+              throw new Error("Invalid response shape");
+            }
+            return json;
+          })()
+        );
+        if (cancelled) return;
+        setItems(data.slice(0, HOME_NEW_ITEMS_COUNT));
+      } catch (e) {
+        if (!cancelled) {
+          setError(e.message || "Failed to load new items");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section id="section-items" className="no-bottom">
       <div className="container">
@@ -14,62 +64,39 @@ const NewItems = () => {
               <div className="small-border bg-color-2"></div>
             </div>
           </div>
-          {new Array(4).fill(0).map((_, index) => (
-            <div className="col-lg-3 col-md-6 col-sm-6 col-xs-12" key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link
-                    to="/author"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="Creator: Monica Lucas"
-                  >
-                    <img className="lazy" src={AuthorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <div className="de_countdown">5h 30m 32s</div>
-
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Link to="/item-details">
-                    <img
-                      src={nftImage}
-                      className="lazy nft__item_preview"
-                      alt=""
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to="/item-details">
-                    <h4>Pinky Ocean</h4>
-                  </Link>
-                  <div className="nft__item_price">3.08 ETH</div>
-                  <div className="nft__item_like">
-                    <i className="fa fa-heart"></i>
-                    <span>69</span>
-                  </div>
-                </div>
+          {loading &&
+            Array.from({ length: HOME_NEW_ITEMS_COUNT }, (_, index) => (
+              <div
+                className="col-lg-3 col-md-6 col-sm-6 col-xs-12"
+                key={`skeleton-${index}`}
+              >
+                <NftCardSkeleton />
               </div>
+            ))}
+          {error && (
+            <div className="col-md-12 text-center py-4 text-danger">
+              {error}
             </div>
-          ))}
+          )}
+          {!loading &&
+            !error &&
+            items.map((item) => (
+              <div
+                className="col-lg-3 col-md-6 col-sm-6 col-xs-12"
+                key={item.id}
+              >
+                <NftItemCard
+                  authorImage={item.authorImage}
+                  nftImage={item.nftImage}
+                  title={item.title}
+                  price={item.price}
+                  likes={item.likes}
+                  expiryDate={item.expiryDate}
+                  nftId={item.nftId}
+                  authorId={item.authorId}
+                />
+              </div>
+            ))}
         </div>
       </div>
     </section>

--- a/src/components/item/ItemDetailsSkeleton.jsx
+++ b/src/components/item/ItemDetailsSkeleton.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import "../common/nft-card-skeleton.css";
+import "./item-details-skeleton.css";
+
+const ItemDetailsSkeleton = () => {
+  return (
+    <section
+      aria-label="section"
+      className="mt90 sm-mt-0 item-details-skeleton"
+      aria-hidden="true"
+    >
+      <div className="container">
+        <div className="row">
+          <div className="col-md-6 text-center">
+            <span className="nft-card-skeleton__pulse item-details-skeleton__hero" />
+          </div>
+          <div className="col-md-6">
+            <div className="item_info">
+              <span className="nft-card-skeleton__pulse item-details-skeleton__title" />
+              <div className="item_info_counts item-details-skeleton__counts">
+                <span className="nft-card-skeleton__pulse item-details-skeleton__pill" />
+                <span className="nft-card-skeleton__pulse item-details-skeleton__pill" />
+              </div>
+              <span className="nft-card-skeleton__pulse item-details-skeleton__line" />
+              <span className="nft-card-skeleton__pulse item-details-skeleton__line item-details-skeleton__line--mid" />
+              <span className="nft-card-skeleton__pulse item-details-skeleton__line item-details-skeleton__line--short" />
+              <div className="d-flex flex-row item-details-skeleton__authors">
+                <div className="mr40 item-details-skeleton__author-block">
+                  <span className="nft-card-skeleton__pulse item-details-skeleton__label" />
+                  <div className="item_author">
+                    <span className="nft-card-skeleton__pulse item-details-skeleton__avatar" />
+                    <span className="nft-card-skeleton__pulse item-details-skeleton__name" />
+                  </div>
+                </div>
+                <div className="item-details-skeleton__author-block">
+                  <span className="nft-card-skeleton__pulse item-details-skeleton__label" />
+                  <div className="item_author">
+                    <span className="nft-card-skeleton__pulse item-details-skeleton__avatar" />
+                    <span className="nft-card-skeleton__pulse item-details-skeleton__name" />
+                  </div>
+                </div>
+              </div>
+              <div className="de_tab tab_simple item-details-skeleton__price-block">
+                <span className="nft-card-skeleton__pulse item-details-skeleton__label" />
+                <span className="nft-card-skeleton__pulse item-details-skeleton__price" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ItemDetailsSkeleton;

--- a/src/components/item/item-details-skeleton.css
+++ b/src/components/item/item-details-skeleton.css
@@ -1,0 +1,91 @@
+.item-details-skeleton {
+  pointer-events: none;
+}
+
+.item-details-skeleton__hero {
+  display: inline-block;
+  width: 100%;
+  max-width: 520px;
+  height: 420px;
+  border-radius: 12px;
+}
+
+.item-details-skeleton__title {
+  display: block;
+  height: 40px;
+  width: 88%;
+  margin-bottom: 22px;
+}
+
+.item-details-skeleton__counts {
+  display: flex;
+  gap: 28px;
+  margin-bottom: 22px;
+}
+
+.item-details-skeleton__pill {
+  width: 88px;
+  height: 22px;
+}
+
+.item-details-skeleton__line {
+  display: block;
+  height: 14px;
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.item-details-skeleton__line--mid {
+  width: 96%;
+}
+
+.item-details-skeleton__line--short {
+  width: 72%;
+  margin-bottom: 28px;
+}
+
+.item-details-skeleton__authors {
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.item-details-skeleton__author-block {
+  min-width: 200px;
+}
+
+.item-details-skeleton__label {
+  display: block;
+  height: 14px;
+  width: 64px;
+  margin-bottom: 12px;
+}
+
+.item-details-skeleton__author-block .item_author {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.item-details-skeleton__avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.item-details-skeleton__name {
+  height: 18px;
+  width: 140px;
+}
+
+.item-details-skeleton__price-block {
+  padding-top: 8px;
+}
+
+.item-details-skeleton__price {
+  display: block;
+  height: 32px;
+  width: 120px;
+  margin-top: 12px;
+}

--- a/src/constants/exploreApi.js
+++ b/src/constants/exploreApi.js
@@ -1,0 +1,28 @@
+export const FUNCTIONS_BASE =
+  "https://us-central1-nft-cloud-functions.cloudfunctions.net";
+
+export const EXPLORE_API_URL = `${FUNCTIONS_BASE}/explore`;
+
+/**
+ * @param {string} filterValue one of "" | "price_low_to_high" | "price_high_to_low" | "likes_high_to_low"
+ * @returns {string}
+ */
+export function getExploreListUrl(filterValue) {
+  if (!filterValue) {
+    return EXPLORE_API_URL;
+  }
+  return `${EXPLORE_API_URL}?filter=${encodeURIComponent(filterValue)}`;
+}
+
+/** Minimum time to show skeleton loading UI (explore + home + item details). */
+export const SKELETON_MIN_MS = 1000;
+
+/**
+ * @param {string|number} authorId
+ * @returns {string}
+ */
+export function authorApiUrl(authorId) {
+  return `${FUNCTIONS_BASE}/author?authorId=${encodeURIComponent(
+    String(authorId)
+  )}`;
+}

--- a/src/hooks/useCountdown.js
+++ b/src/hooks/useCountdown.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+function formatCountdown(remainingMs) {
+  if (remainingMs <= 0) return "Ended";
+  const totalSec = Math.floor(remainingMs / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  return `${h}h ${m}m ${s}s`;
+}
+
+/**
+ * @param {number} expiryDateMs Unix timestamp in milliseconds
+ * @returns {string} Countdown like "5h 30m 32s", or "Ended" when past
+ */
+export function useCountdown(expiryDateMs) {
+  const ts = Number(expiryDateMs);
+  const [label, setLabel] = useState(() =>
+    Number.isFinite(ts) ? formatCountdown(ts - Date.now()) : "—"
+  );
+
+  useEffect(() => {
+    if (!Number.isFinite(ts)) {
+      setLabel("—");
+      return;
+    }
+
+    const tick = () => {
+      const remaining = ts - Date.now();
+      setLabel(formatCountdown(remaining));
+      return remaining <= 0;
+    };
+
+    if (tick()) return;
+
+    const id = setInterval(() => {
+      if (tick()) clearInterval(id);
+    }, 1000);
+
+    return () => clearInterval(id);
+  }, [ts]);
+
+  return label;
+}

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,91 +1,224 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
-import nftImage from "../images/nftImage.jpg";
+import { Link, useSearchParams } from "react-router-dom";
+import ItemDetailsSkeleton from "../components/item/ItemDetailsSkeleton";
+import { SKELETON_MIN_MS } from "../constants/exploreApi";
+import {
+  buildAuthorDisplay,
+  loadItemDetailsData,
+} from "../utils/loadItemDetailsData";
+import { withMinDelay } from "../utils/withMinDelay";
+
+function formatEth(price) {
+  const n = Number(price);
+  if (!Number.isFinite(n)) return "—";
+  return n.toFixed(2);
+}
 
 const ItemDetails = () => {
+  const [searchParams] = useSearchParams();
+  const nftIdParam = searchParams.get("nftId");
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [nft, setNft] = useState(null);
+  const [authorDisplay, setAuthorDisplay] = useState(null);
+
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+  }, [nftIdParam]);
+
+  useEffect(() => {
+    if (!nftIdParam) {
+      setLoading(false);
+      setError("missing_nft");
+      setNft(null);
+      setAuthorDisplay(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const result = await withMinDelay(
+          SKELETON_MIN_MS,
+          loadItemDetailsData(nftIdParam)
+        );
+        if (cancelled) return;
+        setNft(result.nft);
+        setAuthorDisplay(buildAuthorDisplay(result.nft, result.author));
+      } catch (e) {
+        if (!cancelled) {
+          setError(e.message || "Failed to load item");
+          setNft(null);
+          setAuthorDisplay(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [nftIdParam]);
+
+  const authorPath =
+    authorDisplay != null
+      ? `/author?authorId=${encodeURIComponent(authorDisplay.id)}`
+      : "/author";
+
+  const descriptionText =
+    authorDisplay?.bio && authorDisplay.bio.trim().length > 0
+      ? authorDisplay.bio
+      : "No description is available for this item yet.";
 
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>
-        <section aria-label="section" className="mt90 sm-mt-0">
-          <div className="container">
-            <div className="row">
-              <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
+        {loading && <ItemDetailsSkeleton />}
+        {!loading && error === "missing_nft" && (
+          <section aria-label="section" className="mt90 sm-mt-0">
+            <div className="container">
+              <div className="row">
+                <div className="col-md-12 text-center py-5">
+                  <p>This page needs an NFT id in the URL.</p>
+                  <Link to="/explore" className="btn-main">
+                    Back to Explore
+                  </Link>
+                </div>
               </div>
-              <div className="col-md-6">
-                <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+            </div>
+          </section>
+        )}
+        {!loading && error && error !== "missing_nft" && (
+          <section aria-label="section" className="mt90 sm-mt-0">
+            <div className="container">
+              <div className="row">
+                <div className="col-md-12 text-center py-5 text-danger">
+                  <p>{error}</p>
+                  <Link to="/explore" className="btn-main">
+                    Back to Explore
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
+        {!loading && !error && nft && authorDisplay && (
+          <section aria-label="section" className="mt90 sm-mt-0">
+            <div className="container">
+              <div className="row">
+                <div className="col-md-6 text-center">
+                  <img
+                    src={nft.nftImage}
+                    className="img-fluid img-rounded mb-sm-30 nft-image"
+                    alt={nft.title || "NFT"}
+                  />
+                </div>
+                <div className="col-md-6">
+                  <div className="item_info">
+                    <h2>
+                      {nft.title}{" "}
+                      <span className="text-muted">#{nft.nftId}</span>
+                    </h2>
 
-                  <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
-                    </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
-                  </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
-                  <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
-                        </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
-                        </div>
+                    <div className="item_info_counts">
+                      <div className="item_info_views">
+                        <i className="fa fa-eye"></i>
+                        {nft.views != null ? nft.views : "—"}
+                      </div>
+                      <div className="item_info_like">
+                        <i className="fa fa-heart"></i>
+                        {nft.likes}
                       </div>
                     </div>
-                    <div></div>
-                  </div>
-                  <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
-                        </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                    <p>{descriptionText}</p>
+                    <div className="d-flex flex-row">
+                      <div className="mr40">
+                        <h6>Owner</h6>
+                        <div className="item_author">
+                          <div className="author_list_pp">
+                            <Link to={authorPath}>
+                              <img
+                                className="lazy"
+                                src={authorDisplay.image}
+                                alt=""
+                              />
+                              <i className="fa fa-check"></i>
+                            </Link>
+                          </div>
+                          <div className="author_list_info">
+                            <Link to={authorPath}>{authorDisplay.name}</Link>
+                            {authorDisplay.username ? (
+                              <div className="text-muted small">
+                                @{authorDisplay.username}
+                              </div>
+                            ) : null}
+                          </div>
                         </div>
                       </div>
+                      <div></div>
                     </div>
-                    <div className="spacer-40"></div>
-                    <h6>Price</h6>
-                    <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
+                    <div className="de_tab tab_simple">
+                      <div className="de_tab_content">
+                        <h6>Creator</h6>
+                        <div className="item_author">
+                          <div className="author_list_pp">
+                            <Link to={authorPath}>
+                              <img
+                                className="lazy"
+                                src={authorDisplay.image}
+                                alt=""
+                              />
+                              <i className="fa fa-check"></i>
+                            </Link>
+                          </div>
+                          <div className="author_list_info">
+                            <Link to={authorPath}>{authorDisplay.name}</Link>
+                            {authorDisplay.username ? (
+                              <div className="text-muted small">
+                                @{authorDisplay.username}
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                      {authorDisplay.followersLabel ? (
+                        <>
+                          <div className="spacer-20"></div>
+                          <p className="mb-0">{authorDisplay.followersLabel}</p>
+                        </>
+                      ) : null}
+                      {authorDisplay.wallet ? (
+                        <>
+                          <div className="spacer-20"></div>
+                          <h6>Wallet</h6>
+                          <p className="profile_wallet small text-break">
+                            {authorDisplay.wallet}
+                          </p>
+                        </>
+                      ) : null}
+                      <div className="spacer-40"></div>
+                      <h6>Price</h6>
+                      <div className="nft-item-price">
+                        <img src={EthImage} alt="" />
+                        <span>{formatEth(nft.price)}</span>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/utils/loadItemDetailsData.js
+++ b/src/utils/loadItemDetailsData.js
@@ -1,0 +1,94 @@
+import { authorApiUrl, EXPLORE_API_URL, FUNCTIONS_BASE } from "../constants/exploreApi";
+
+/**
+ * @param {string|number} authorId
+ * @returns {Promise<object|null>}
+ */
+async function fetchAuthorRecord(authorId) {
+  const urls = [
+    authorApiUrl(authorId),
+    `${FUNCTIONS_BASE}/authors?authorId=${encodeURIComponent(String(authorId))}`,
+  ];
+
+  for (const url of urls) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const body = await res.json();
+      if (body == null) continue;
+      if (Array.isArray(body) && body.length > 0) {
+        const first = body[0];
+        if (first && typeof first === "object") return first;
+        continue;
+      }
+      if (typeof body === "object") {
+        if (body.data && typeof body.data === "object") return body.data;
+        if (body.author && typeof body.author === "object") return body.author;
+        return body;
+      }
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+/**
+ * Loads catalog entry for nftId and author profile when available.
+ * @param {string} nftIdStr raw query param (digits)
+ * @returns {Promise<{ nft: object, author: object|null }>}
+ */
+export async function loadItemDetailsData(nftIdStr) {
+  const res = await fetch(EXPLORE_API_URL);
+  if (!res.ok) {
+    throw new Error(`Catalog request failed (${res.status})`);
+  }
+  const items = await res.json();
+  if (!Array.isArray(items)) {
+    throw new Error("Invalid catalog response");
+  }
+
+  const nft = items.find((row) => String(row.nftId) === String(nftIdStr));
+  if (!nft) {
+    throw new Error("NFT not found");
+  }
+
+  const author = await fetchAuthorRecord(nft.authorId);
+  return { nft, author };
+}
+
+/**
+ * @param {object} nft explore row
+ * @param {object|null} author author endpoint payload or null
+ */
+export function buildAuthorDisplay(nft, author) {
+  const a = author || {};
+  const followersRaw =
+    a.followers ??
+    a.followerCount ??
+    a.followersCount ??
+    a.follower_count;
+  let followersLabel = null;
+  if (followersRaw != null && followersRaw !== "") {
+    followersLabel = `${followersRaw} followers`;
+  }
+
+  return {
+    id: nft.authorId,
+    image:
+      a.authorImage ||
+      a.image ||
+      a.avatarUrl ||
+      a.avatar ||
+      nft.authorImage,
+    name:
+      a.name ||
+      a.authorName ||
+      a.displayName ||
+      `Creator #${nft.authorId}`,
+    username: a.username || a.handle || a.twitter || "",
+    wallet: a.wallet || a.walletAddress || a.address || "",
+    followersLabel,
+    bio: a.bio || a.description || a.about || "",
+  };
+}

--- a/src/utils/withMinDelay.js
+++ b/src/utils/withMinDelay.js
@@ -1,0 +1,25 @@
+/**
+ * Waits for `promise` and ensures at least `minMs` milliseconds elapse
+ * before resolving or rejecting.
+ * @template T
+ * @param {number} minMs
+ * @param {Promise<T>} promise
+ * @returns {Promise<T>}
+ */
+export async function withMinDelay(minMs, promise) {
+  const start = Date.now();
+  try {
+    const result = await promise;
+    const elapsed = Date.now() - start;
+    if (elapsed < minMs) {
+      await new Promise((resolve) => setTimeout(resolve, minMs - elapsed));
+    }
+    return result;
+  } catch (err) {
+    const elapsed = Date.now() - start;
+    if (elapsed < minMs) {
+      await new Promise((resolve) => setTimeout(resolve, minMs - elapsed));
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Task:
1. Dynamically pull from api
2. Have countdown timer where applicable
3. Only show 8 cards and then paginate with Load More button that loads 4 more
4. Reuse same card component from New Items
5. Skeleton loading on explore and home page
6. Implement sorting functionality from backend 


Why: 
1. Increase UI functionality
2. Show when NFT timer ends
3. Pagination for quicker, lighter loading
4. Skeleton for optics

How:
1. Added reusable props and components
2. Added skeleton state with 1s load
3. Paginated with Load More button using items.length
4. Pulled API data into each unique item-details page for individual authors
5. For the filter and sorting menus:
       -filter state (default "").
       -#filter-items is controlled with value={filter} and onChange → setFilter.
       -useEffect depends on [filter] and calls fetch(getExploreListUrl(filter)) inside the existing withMinDelay(SKELETON_MIN_MS, …) block.

Screenshots:
<img width="1366" height="890" alt="Screenshot 2026-04-22 at 7 07 43 PM" src="https://github.com/user-attachments/assets/7a1011c5-fa78-4744-a29d-eb6e50bac060" />
